### PR TITLE
Description for user agent

### DIFF
--- a/custom_components/indego/translations/de.json
+++ b/custom_components/indego/translations/de.json
@@ -13,6 +13,9 @@
                     "expose_mower": "Indego Mähroboter als Mower Entität in HomeAssistant anlegen",
                     "expose_vacuum": "Indego Mähroboter als Vacuum Entität in HomeAssistant anlegen"
                 },
+                "data_description": {
+                    "user_agent": "Im Fall von HTTP 4XX Fehlern (besonders Reason: 403, message='Forbidden') kann es helfen den User Agent zu ändern. Dieser sollte nicht Homeassistant oder HA enthalten."
+                },
                 "description": "Erweiterte Einstellung des Bosch Indego Component."
             },
             "mower": {
@@ -38,6 +41,9 @@
                     "expose_mower": "Indego Mähroboter als Mower Entität in HomeAssistant anlegen",
                     "expose_vacuum": "Indego Mähroboter als Vacuum Entität in HomeAssistant anlegen",
                     "show_all_alerts": "Zeige den kompletten Alarm Verlauf in HomeAssistant. Dies wird für die meisten Nutzer nicht empfohlen, da es signifikanten Einfluss auf die Größe der HomeAssistant Datenbank haben kann."
+                },
+                "data_description": {
+                    "user_agent": "Im Fall von HTTP 4XX Fehlern (besonders Reason: 403, message='Forbidden') kann es helfen den User Agent zu ändern. Dieser sollte nicht Homeassistant oder HA enthalten."
                 }
             }
         }

--- a/custom_components/indego/translations/en.json
+++ b/custom_components/indego/translations/en.json
@@ -13,6 +13,9 @@
                     "expose_mower": "Expose Indego mower as mower entity in HomeAssistant",
                     "expose_vacuum": "Expose Indego mower as vacuum entity in HomeAssistant"
                 },
+                "data_description": {
+                    "user_agent": "In case of HTTP 4XX errors (especially Reason: 403, message='Forbidden') it might help to change the User Agent. Should not contain Homeassistant or HA."
+                },
                 "description": "Advanced settings of the Bosch Indego component."
             },
             "mower": {
@@ -38,6 +41,9 @@
                   "expose_mower": "Expose Indego mower as mower entity in HomeAssistant",
                   "expose_vacuum": "Expose Indego mower as vacuum entity in HomeAssistant",
                   "show_all_alerts": "Show the full alert history into HomeAssistant. This is not recommended for most users, it might have a significant impact on the HomeAssistant database size!"
+              },
+              "data_description": {
+                  "user_agent": "In case of HTTP 4XX errors (especially Reason: 403, message='Forbidden') it might help to change the User Agent. Should not contain Homeassistant or HA."
               }
           }
       }

--- a/custom_components/indego/translations/fr.json
+++ b/custom_components/indego/translations/fr.json
@@ -13,6 +13,9 @@
                     "expose_mower": "Exposer la tondeuse Indego comme une entité tondeuse dans HomeAssistant",
                     "expose_vacuum": "Exposer la tondeuse Indego comme une entité aspirateur dans HomeAssistant"
                 },
+                "data_description": {
+                    "user_agent": "In case of HTTP 4XX errors (especially Reason: 403, message='Forbidden') it might help to change the User Agent. Should not contain Homeassistant or HA."
+                },
                 "description": "Réglages avancés du composant Bosch Indego. Peuvent être laissés inchangés pour la plupart des utilisateurs."
             },
             "mower": {
@@ -38,6 +41,9 @@
                   "expose_mower": "Exposer la tondeuse Indego comme une entité tondeuse dans HomeAssistant",
                   "expose_vacuum": "Exposer la tondeuse Indego comme une entité aspirateur dans HomeAssistant",
                   "show_all_alerts": "Montrer l'historique complet des alertes dans HomeAssistant. Non recommandé pour la plupart des utilisateurs, l'impact sur la taille de la base de données HomeAssistant peut être assez important!"
+              },
+              "data_description": {
+                  "user_agent": "In case of HTTP 4XX errors (especially Reason: 403, message='Forbidden') it might help to change the User Agent. Should not contain Homeassistant or HA."
               }
           }
       }

--- a/custom_components/indego/translations/fr.json
+++ b/custom_components/indego/translations/fr.json
@@ -14,7 +14,7 @@
                     "expose_vacuum": "Exposer la tondeuse Indego comme une entité aspirateur dans HomeAssistant"
                 },
                 "data_description": {
-                    "user_agent": "In case of HTTP 4XX errors (especially Reason: 403, message='Forbidden') it might help to change the User Agent. Should not contain Homeassistant or HA."
+                    "user_agent": "En cas d'erreurs HTTP 4XX (notamment avec le code 403 et le message « Forbidden »), il peut être utile de modifier l'agent utilisateur. Celui-ci ne doit pas contenir les termes « Homeassistant » ou « HA »."
                 },
                 "description": "Réglages avancés du composant Bosch Indego. Peuvent être laissés inchangés pour la plupart des utilisateurs."
             },
@@ -43,7 +43,7 @@
                   "show_all_alerts": "Montrer l'historique complet des alertes dans HomeAssistant. Non recommandé pour la plupart des utilisateurs, l'impact sur la taille de la base de données HomeAssistant peut être assez important!"
               },
               "data_description": {
-                  "user_agent": "In case of HTTP 4XX errors (especially Reason: 403, message='Forbidden') it might help to change the User Agent. Should not contain Homeassistant or HA."
+                  "user_agent": "En cas d'erreurs HTTP 4XX (notamment avec le code 403 et le message « Forbidden »), il peut être utile de modifier l'agent utilisateur. Celui-ci ne doit pas contenir les termes « Homeassistant » ou « HA »."
               }
           }
       }

--- a/custom_components/indego/translations/nl.json
+++ b/custom_components/indego/translations/nl.json
@@ -13,6 +13,9 @@
                     "expose_mower": "Voeg de Indego robotmaaier toe als grasmaaier entiteit aan HomeAssistant",
                     "expose_vacuum": "Voeg de Indego robotmaaier toe als stofzuiger entiteit aan HomeAssistant"
                 },
+                "data_description": {
+                    "user_agent": "In case of HTTP 4XX errors (especially Reason: 403, message='Forbidden') it might help to change the User Agent. Should not contain Homeassistant or HA."
+                },
                 "description": "Geavanceerde instellingen van het Bosch Indego component."
             },
             "mower": {
@@ -38,6 +41,9 @@
                   "expose_mower": "Voeg de Indego robotmaaier toe als grasmaaier entiteit aan HomeAssistant",
                   "expose_vacuum": "Voeg de Indego robotmaaier toe als stofzuiger entiteit aan HomeAssistant",
                   "show_all_alerts": "Toon de volledige melding/waarschuwing geschiedenis in HomeAssistant. Dit wordt niet aangeraden voor de meeste gebruikers, het heeft mogelijk een significante impact op de HomeAssistant database!"
+              },
+              "data_description": {
+                  "user_agent": "In case of HTTP 4XX errors (especially Reason: 403, message='Forbidden') it might help to change the User Agent. Should not contain Homeassistant or HA."
               }
           }
       }

--- a/custom_components/indego/translations/nl.json
+++ b/custom_components/indego/translations/nl.json
@@ -14,7 +14,7 @@
                     "expose_vacuum": "Voeg de Indego robotmaaier toe als stofzuiger entiteit aan HomeAssistant"
                 },
                 "data_description": {
-                    "user_agent": "In case of HTTP 4XX errors (especially Reason: 403, message='Forbidden') it might help to change the User Agent. Should not contain Homeassistant or HA."
+                    "user_agent": "Bij HTTP 4XX-fouten (met name Reason: 403, message=‘Forbidden’) kan het helpen om de User Agent aan te passen. Deze mag geen Homeassistant of HA bevatten."
                 },
                 "description": "Geavanceerde instellingen van het Bosch Indego component."
             },
@@ -43,7 +43,7 @@
                   "show_all_alerts": "Toon de volledige melding/waarschuwing geschiedenis in HomeAssistant. Dit wordt niet aangeraden voor de meeste gebruikers, het heeft mogelijk een significante impact op de HomeAssistant database!"
               },
               "data_description": {
-                  "user_agent": "In case of HTTP 4XX errors (especially Reason: 403, message='Forbidden') it might help to change the User Agent. Should not contain Homeassistant or HA."
+                  "user_agent": "Bij HTTP 4XX-fouten (met name Reason: 403, message=‘Forbidden’) kan het helpen om de User Agent aan te passen. Deze mag geen Homeassistant of HA bevatten."
               }
           }
       }

--- a/custom_components/indego/translations/pl.json
+++ b/custom_components/indego/translations/pl.json
@@ -13,7 +13,7 @@
                     "expose_vacuum": "Wyświetl kosiarkę Indego jako encję odkurzacza w HomeAssistant"
                 },
                 "data_description": {
-                    "user_agent": "In case of HTTP 4XX errors (especially Reason: 403, message='Forbidden') it might help to change the User Agent. Should not contain Homeassistant or HA."
+                    "user_agent": "W przypadku błędów HTTP 4XX (zwłaszcza Reason: 403, message=»Forbidden«) pomocna może okazać się zmiana agenta użytkownika. Nie powinien on zawierać słów „Homeassistant” ani „HA”."
                 },
                 "description": "Ustawienia zaawansowane komponentu Bosch Indego."
             },
@@ -38,7 +38,7 @@
                   "show_all_alerts": "Pokaż pełną historię alertów w HomeAssistant. Nie rekomendowane dla większości użytkowników, może mieć wpływ na znaczące zwiększenie rozmiaru bazy danych HomeAssistant!"
               },
               "data_description": {
-                  "user_agent": "In case of HTTP 4XX errors (especially Reason: 403, message='Forbidden') it might help to change the User Agent. Should not contain Homeassistant or HA."
+                  "user_agent": "W przypadku błędów HTTP 4XX (zwłaszcza Reason: 403, message=»Forbidden«) pomocna może okazać się zmiana agenta użytkownika. Nie powinien on zawierać słów „Homeassistant” ani „HA”."
               }
           }
       }

--- a/custom_components/indego/translations/pl.json
+++ b/custom_components/indego/translations/pl.json
@@ -12,6 +12,9 @@
                     "expose_mower": "Wyświetl kosiarkę Indego jako encję kosiarki w HomeAssistant",
                     "expose_vacuum": "Wyświetl kosiarkę Indego jako encję odkurzacza w HomeAssistant"
                 },
+                "data_description": {
+                    "user_agent": "In case of HTTP 4XX errors (especially Reason: 403, message='Forbidden') it might help to change the User Agent. Should not contain Homeassistant or HA."
+                },
                 "description": "Ustawienia zaawansowane komponentu Bosch Indego."
             },
             "mower": {
@@ -33,6 +36,9 @@
                   "expose_mower": "Wyświetl kosiarkę Indego jako encję kosiarki w HomeAssistant",
                   "expose_vacuum": "Wyświetl kosiarkę Indego jako encję odkurzacza w HomeAssistant",
                   "show_all_alerts": "Pokaż pełną historię alertów w HomeAssistant. Nie rekomendowane dla większości użytkowników, może mieć wpływ na znaczące zwiększenie rozmiaru bazy danych HomeAssistant!"
+              },
+              "data_description": {
+                  "user_agent": "In case of HTTP 4XX errors (especially Reason: 403, message='Forbidden') it might help to change the User Agent. Should not contain Homeassistant or HA."
               }
           }
       }

--- a/custom_components/indego/translations/sk.json
+++ b/custom_components/indego/translations/sk.json
@@ -14,7 +14,7 @@
                     "expose_vacuum": "Odhaľte kosačku Indego ako vákuovú entitu v aplikácii HomeAssistant"
                 },
                 "data_description": {
-                    "user_agent": "In case of HTTP 4XX errors (especially Reason: 403, message='Forbidden') it might help to change the User Agent. Should not contain Homeassistant or HA."
+                    "user_agent": "V prípade chýb HTTP 4XX (najmä Reason: 403, message=‚Forbidden‘) môže pomôcť zmena User Agent. Nemal by obsahovať Homeassistant ani HA."
                 },
                 "description": "Rozšírené nastavenia komponentu Bosch Indego."
             },
@@ -43,7 +43,7 @@
                   "show_all_alerts": "Zobrazte celú históriu upozornení v aplikácii HomeAssistant. Toto sa neodporúča väčšine používateľov, môže to mať významný vplyv na veľkosť databázy HomeAssistant!"
               },
               "data_description": {
-                  "user_agent": "In case of HTTP 4XX errors (especially Reason: 403, message='Forbidden') it might help to change the User Agent. Should not contain Homeassistant or HA."
+                  "user_agent": "V prípade chýb HTTP 4XX (najmä Reason: 403, message=‚Forbidden‘) môže pomôcť zmena User Agent. Nemal by obsahovať Homeassistant ani HA."
               }
           }
       }

--- a/custom_components/indego/translations/sk.json
+++ b/custom_components/indego/translations/sk.json
@@ -13,6 +13,9 @@
                     "expose_mower": "Odhaľte kosačku Indego ako entitu kosačky v aplikácii HomeAssistant",
                     "expose_vacuum": "Odhaľte kosačku Indego ako vákuovú entitu v aplikácii HomeAssistant"
                 },
+                "data_description": {
+                    "user_agent": "In case of HTTP 4XX errors (especially Reason: 403, message='Forbidden') it might help to change the User Agent. Should not contain Homeassistant or HA."
+                },
                 "description": "Rozšírené nastavenia komponentu Bosch Indego."
             },
             "mower": {
@@ -38,6 +41,9 @@
                   "expose_mower": "Odhaľte kosačku Indego ako entitu kosačky v aplikácii HomeAssistant",
                   "expose_vacuum": "Odhaľte kosačku Indego ako vákuovú entitu v aplikácii HomeAssistant",
                   "show_all_alerts": "Zobrazte celú históriu upozornení v aplikácii HomeAssistant. Toto sa neodporúča väčšine používateľov, môže to mať významný vplyv na veľkosť databázy HomeAssistant!"
+              },
+              "data_description": {
+                  "user_agent": "In case of HTTP 4XX errors (especially Reason: 403, message='Forbidden') it might help to change the User Agent. Should not contain Homeassistant or HA."
               }
           }
       }


### PR DESCRIPTION
Added a description for the Text field User Agent. I have added "data_description" for "user-agent" config. This should make it easier for the user to understand what the user-agent is used for. Hoping this will reduce the number of opened issues because of user-agent restrictions on Bosch side.
sk.json, nl.json, pl.json and fr.json were translated with DeepL