### PR TITLE
Fix for delete_all_alerts and add new service set_calendar_slot and 2 new sensors for calendar time slots

### DIFF
--- a/custom_components/indego/__init__.py
+++ b/custom_components/indego/__init__.py
@@ -94,6 +94,19 @@ SERVICE_SCHEMA_DOWNLOAD_MAP = vol.Schema({
     vol.Optional(CONF_MOWER_SERIAL): cv.string
 })
 
+SERVICE_SCHEMA_SET_CALENDAR_SLOT = vol.Schema({
+    vol.Optional(CONF_MOWER_SERIAL): cv.string,
+    vol.Optional(CONF_CALENDAR_TYPE, default="calendar"): vol.In(["calendar", "predictive"]),
+    vol.Required(CONF_DAY): vol.In([
+        "monday", "tuesday", "wednesday", "thursday",
+        "friday", "saturday", "sunday",
+    ]),
+    vol.Required(CONF_SLOT): vol.In([1, 2]),
+    vol.Optional(CONF_ENABLED, default=True): cv.boolean,
+    vol.Optional(CONF_START): cv.string,
+    vol.Optional(CONF_END): cv.string,
+})
+
 
 def FUNC_ICON_MOWER_ALERT(state):
     if state:
@@ -418,6 +431,59 @@ ENTITY_DEFINITIONS = {
         CONF_TRANSLATION_KEY: "indego_smartmowing",
         CONF_ENTITY_CATEGORY: EntityCategory.CONFIG,
     },
+    ENTITY_PREDICTIVE_CALENDAR_SLOTS: {
+        CONF_TYPE: SENSOR_TYPE,
+        CONF_ICON: "mdi:calendar-remove",
+        CONF_DEVICE_CLASS: None,
+        CONF_UNIT_OF_MEASUREMENT: None,
+        CONF_ATTR: [
+            "last_updated",
+            "smartmowing_enabled",
+            "today_slot_1",
+            "today_slot_2",
+            "monday_slot_1",
+            "monday_slot_2",
+            "tuesday_slot_1",
+            "tuesday_slot_2",
+            "wednesday_slot_1",
+            "wednesday_slot_2",
+            "thursday_slot_1",
+            "thursday_slot_2",
+            "friday_slot_1",
+            "friday_slot_2",
+            "saturday_slot_1",
+            "saturday_slot_2",
+            "sunday_slot_1",
+            "sunday_slot_2",
+        ],
+        CONF_TRANSLATION_KEY: "predictive_calendar_slots",
+    },
+    ENTITY_CALENDAR_SLOTS: {
+        CONF_TYPE: SENSOR_TYPE,
+        CONF_ICON: "mdi:calendar-clock",
+        CONF_DEVICE_CLASS: None,
+        CONF_UNIT_OF_MEASUREMENT: None,
+        CONF_ATTR: [
+            "last_updated",
+            "today_slot_1",
+            "today_slot_2",
+            "monday_slot_1",
+            "monday_slot_2",
+            "tuesday_slot_1",
+            "tuesday_slot_2",
+            "wednesday_slot_1",
+            "wednesday_slot_2",
+            "thursday_slot_1",
+            "thursday_slot_2",
+            "friday_slot_1",
+            "friday_slot_2",
+            "saturday_slot_1",
+            "saturday_slot_2",
+            "sunday_slot_1",
+            "sunday_slot_2",
+        ],
+        CONF_TRANSLATION_KEY: "calendar_slots",
+    },
 }
 
 
@@ -430,6 +496,164 @@ def last_updated_now() -> str:
         "%Y-%m-%d %H:%M:%S"
     )
 
+def _format_calendar_slot(slot) -> str:
+    return (
+        f"{slot.StHr:02d}:{slot.StMin:02d}-"
+        f"{slot.EnHr:02d}:{slot.EnMin:02d}"
+    )
+
+
+def _calendar_slots_by_day(calendar) -> dict:
+    result = {}
+
+    day_names = [
+        "monday",
+        "tuesday",
+        "wednesday",
+        "thursday",
+        "friday",
+        "saturday",
+        "sunday",
+    ]
+
+    for day_name in day_names:
+        result[f"{day_name}_slot_1"] = "not enabled"
+        result[f"{day_name}_slot_2"] = "not enabled"
+
+    if calendar is None or not getattr(calendar, "days", None):
+        return result
+
+    for day in calendar.days:
+        day_name = getattr(day, "day_name", None)
+        if day_name not in day_names:
+            continue
+
+        slots = getattr(day, "slots", [])
+
+        for index in range(2):
+            attr_name = f"{day_name}_slot_{index + 1}"
+
+            if index >= len(slots):
+                result[attr_name] = "not configured"
+                continue
+
+            slot = slots[index]
+
+            if getattr(slot, "En", False):
+                result[attr_name] = _format_calendar_slot(slot)
+            else:
+                result[attr_name] = "not enabled"
+
+    return result
+
+def _today_calendar_slots(slots_by_day: dict) -> list:
+    today_name = _today_calendar_day_name()
+
+    return [
+        slot
+        for slot in [
+            slots_by_day.get(f"{today_name}_slot_1"),
+            slots_by_day.get(f"{today_name}_slot_2"),
+        ]
+        if slot not in (None, "not enabled", "not configured")
+    ]
+
+def _today_calendar_day_name() -> str:
+    return datetime.now().strftime("%A").lower()
+
+DAY_NAME_TO_INDEX = {
+    "monday": 0,
+    "tuesday": 1,
+    "wednesday": 2,
+    "thursday": 3,
+    "friday": 4,
+    "saturday": 5,
+    "sunday": 6,
+}
+
+
+def _parse_slot_time(value: str) -> tuple[int, int]:
+    hour, minute = value.split(":", 1)
+    hour = int(hour)
+    minute = int(minute)
+
+    if hour < 0 or hour > 23 or minute < 0 or minute > 59:
+        raise ValueError("Time must be between 00:00 and 23:59")
+
+    return hour, minute
+
+
+def _calendar_to_payload(calendar, selected_cal: int = 1) -> dict:
+    days = []
+
+    for day_index in range(7):
+        days.append({
+            "day": day_index,
+            "slots": [
+                {"En": False, "StHr": None, "StMin": None, "EnHr": None, "EnMin": None},
+                {"En": False, "StHr": None, "StMin": None, "EnHr": None, "EnMin": None},
+            ],
+        })
+
+    if calendar is not None and getattr(calendar, "days", None):
+        for day in calendar.days:
+            day_index = getattr(day, "day", None)
+            if day_index is None or day_index < 0 or day_index > 6:
+                continue
+
+            slots = getattr(day, "slots", [])
+            for slot_index in range(min(len(slots), 2)):
+                slot = slots[slot_index]
+                days[day_index]["slots"][slot_index] = {
+                    "En": bool(getattr(slot, "En", False)),
+                    "StHr": getattr(slot, "StHr", None),
+                    "StMin": getattr(slot, "StMin", None),
+                    "EnHr": getattr(slot, "EnHr", None),
+                    "EnMin": getattr(slot, "EnMin", None),
+                }
+
+    return {
+        "sel_cal": selected_cal,
+        "cals": [
+            {
+                "cal": getattr(calendar, "cal", selected_cal) if calendar else selected_cal,
+                "days": days,
+            }
+        ],
+    }
+
+
+def _set_payload_slot(payload: dict, day_name: str, slot_number: int, enabled: bool, start: str | None, end: str | None) -> dict:
+    day_index = DAY_NAME_TO_INDEX[day_name]
+    slot_index = slot_number - 1
+
+    slot = payload["cals"][0]["days"][day_index]["slots"][slot_index]
+
+    if not enabled:
+        slot.update({
+            "En": False,
+            "StHr": None,
+            "StMin": None,
+            "EnHr": None,
+            "EnMin": None,
+        })
+        return payload
+
+    if not start or not end:
+        raise ValueError("start and end are required when enabled is true")
+
+    start_hour, start_minute = _parse_slot_time(start)
+    end_hour, end_minute = _parse_slot_time(end)
+
+    slot.update({
+        "En": True,
+        "StHr": start_hour,
+        "StMin": start_minute,
+        "EnHr": end_hour,
+        "EnMin": end_minute,
+    })
+
+    return payload
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Load a config entry."""
@@ -543,49 +767,39 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         instance = find_instance_for_mower_service_call(call)
         _LOGGER.info("Deleting all alerts from mower: %s", instance._serial)
 
-        await instance._update_alerts()
+        max_rounds = 30
 
-        # Loop to delete all alerts (API may return only ~10 at a time)
-        max_attempts = 10  # Prevent infinite loops
-        attempt = 0
-        while attempt < max_attempts:
-            alerts_before = len(instance._indego_client.alerts)
-            _LOGGER.debug(
-                "Delete attempt %d/%d - Current alert count: %d",
-                attempt + 1,
-                max_attempts,
-                alerts_before,
+        for round_num in range(1, max_rounds + 1):
+            await instance._update_alerts()
+
+            loaded_alerts = len(instance._indego_client.alerts or [])
+            total_alerts = getattr(instance._indego_client, "alerts_count", loaded_alerts)
+
+            _LOGGER.info(
+                "Delete-all round %d/%d for mower %s: loaded=%d total=%s",
+                round_num,
+                max_rounds,
+                instance._serial,
+                loaded_alerts,
+                total_alerts,
             )
 
-            if alerts_before == 0:
-                _LOGGER.info("All alerts successfully deleted")
+            if loaded_alerts == 0 and total_alerts == 0:
+                _LOGGER.info("All alerts deleted for mower: %s", instance._serial)
+                break
+
+            if loaded_alerts == 0:
+                _LOGGER.warning(
+                    "Alert count is %s but no alerts are loaded for mower %s; stopping delete loop",
+                    total_alerts,
+                    instance._serial,
+                )
                 break
 
             await instance._indego_client.delete_all_alerts()
-            await asyncio.sleep(5)  # Wait 5 seconds between deletions
-            await instance._update_alerts()
+            await asyncio.sleep(5)
 
-            alerts_after = len(instance._indego_client.alerts)
-            _LOGGER.debug(
-                "Delete attempt %d/%d - Alert count after: %d",
-                attempt + 1,
-                max_attempts,
-                alerts_after,
-            )
-
-            attempt += 1
-
-            # If no progress, stop trying
-            if alerts_after >= alerts_before:
-                _LOGGER.warning("No progress in alert deletion after %d attempts", attempt)
-                break
-
-        if attempt >= max_attempts and len(instance._indego_client.alerts) > 0:
-            _LOGGER.error(
-                "Failed to delete all alerts after %d attempts (%d alerts remaining)",
-                max_attempts,
-                len(instance._indego_client.alerts),
-            )
+        await instance._update_alerts()
 
     async def async_read_alert(call):
         """Handle the service call."""
@@ -611,6 +825,26 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         instance = find_instance_for_mower_service_call(call)
         _LOGGER.info("Downloading lawn map for mower: %s", instance._serial)
         await instance.download_and_store_map()
+
+    async def async_set_calendar_slot(call):
+        """Handle set_calendar_slot service call."""
+        instance = find_instance_for_mower_service_call(call)
+
+        calendar_type = call.data[CONF_CALENDAR_TYPE]
+        day = call.data[CONF_DAY]
+        slot = call.data[CONF_SLOT]
+        enabled = call.data[CONF_ENABLED]
+        start = call.data.get(CONF_START)
+        end = call.data.get(CONF_END)
+
+        await instance.async_set_calendar_slot(
+            calendar_type=calendar_type,
+            day=day,
+            slot=slot,
+            enabled=enabled,
+            start=start,
+            end=end,
+        )
 
     # In HASS we can have multiple Indego component instances as long as the mower serial is unique.
     # So the mower services should only need to be registered for the first instance.
@@ -660,6 +894,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             async_download_map,
             schema=SERVICE_SCHEMA_DOWNLOAD_MAP
         )
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_NAME_SET_CALENDAR_SLOT,
+            async_set_calendar_slot,
+            schema=SERVICE_SCHEMA_SET_CALENDAR_SLOT,
+        )
 
         hass.data[DOMAIN][CONF_SERVICES_REGISTERED] = entry.entry_id
         _LOGGER.info("Successfully registered all Indego services")
@@ -692,14 +932,31 @@ class IndegoHub:
     # State-specific stuck detection timeouts (in seconds)
     # Maps mower state codes to how long to wait before marking as stuck
     STUCK_DETECTION_TIMEOUTS = {
-        513: 60,    # IN_LAWN_MOWING - Normal mowing
-        516: 120,   # IN_LAWN_MAPPING - Learning lawn (slow, covers entire area)
-        518: 70,    # IN_LAWN_BORDER_CUT - Border cut (precise, but faster than mapping)
-        520: 120,   # IN_LAWN_MAPPING_PAUSED - Learning paused (still slow)
-        521: 70,    # IN_LAWN_BORDER_CUTTING - Border cutting (precise, but faster than mapping)
-        523: 120,   # IN_LAWN_SPOT_MOWING - Spot mowing (very precise, small area)
-        524: 120,   # IN_LAWN_RANDOM_MOWING - Random mowing
-        525: 120,   # IN_LAWN_SPOT_MOWING_COMPLETE - Spot mowing complete
+        513: 60,
+        517: 120,
+        518: 70,
+        519: 120,
+        521: 70,
+        523: 120,
+        524: 120,
+        768: 120,
+        769: 120,
+        770: 120,
+        771: 120,
+        772: 120,
+        773: 120,
+        774: 120,
+        775: 120,
+        776: 120,
+    }
+
+    STUCK_IGNORED_STATES = {
+        266,  # Leaving Dock
+        514,  # Relocalising
+        515,  # Loading map
+        516,  # Learning lawn / calibrating-like
+        520,  # Mapping paused
+        525,  # Spot mowing complete
     }
 
     # Grace period after mowing session starts (in seconds)
@@ -759,6 +1016,54 @@ class IndegoHub:
         )
         self._indego_client.set_default_header(HTTP_HEADER_USER_AGENT, user_agent)
 
+    async def async_set_calendar_slot(
+        self,
+        calendar_type: str,
+        day: str,
+        slot: int,
+        enabled: bool,
+        start: str | None = None,
+        end: str | None = None,
+    ):
+        """Set one calendar slot."""
+        _LOGGER.info(
+            "Setting %s calendar slot: day=%s slot=%s enabled=%s start=%s end=%s mower=%s",
+            calendar_type,
+            day,
+            slot,
+            enabled,
+            start,
+            end,
+            self._serial,
+        )
+
+        if calendar_type == "predictive":
+            await self._indego_client.update_predictive_calendar()
+            calendar = getattr(self._indego_client, "predictive_calendar", None)
+
+            payload = _calendar_to_payload(calendar, selected_cal=1)
+            payload = _set_payload_slot(payload, day, slot, enabled, start, end)
+
+            await self._indego_client.put_predictive_cal(payload)
+            await self._update_predictive_calendar()
+            return
+
+        await self._indego_client.update_calendar()
+        calendar = getattr(self._indego_client, "calendar", None)
+
+        payload = _calendar_to_payload(calendar, selected_cal=1)
+        payload = _set_payload_slot(payload, day, slot, enabled, start, end)
+
+        # Experimental: pyIndego documents GET /calendar, but not PUT /calendar.
+        result = await self._indego_client.put(
+            f"alms/{self._serial}/calendar",
+            payload,
+        )
+
+        _LOGGER.warning("SET CALENDAR SLOT RESULT = %r", result)
+
+        await self._update_calendar()
+
     async def async_send_command_to_client(self, command: str):
         """Send a mower command to the Indego client."""
         _LOGGER.debug("Sending command to mower (%s): '%s'", self._serial, command)
@@ -801,7 +1106,7 @@ class IndegoHub:
                 if self._features[CONF_EXPOSE_INDEGO_AS_MOWER]:
                     self.entities[entity_key] = IndegoLawnMower(
                         f"indego_{self._serial}",
-                        self._mower_name,
+                        None,
                         device_info,
                         self
                     )
@@ -1035,6 +1340,8 @@ class IndegoHub:
                 self._update_alerts(),
                 self._update_last_completed_mow(),
                 self._update_next_mow(),
+                self._update_predictive_calendar(),
+                self._update_calendar(),
             ],
             return_exceptions=True,
         )
@@ -1236,6 +1543,73 @@ class IndegoHub:
 
         except Exception as exc:
             _LOGGER.error("Unexpected error while updating operating data: %s", str(exc))
+
+    async def _update_predictive_calendar(self):
+        """Update predictive calendar data / smart mowing blocked slots."""
+        _LOGGER.debug("Fetching predictive calendar from Bosch API")
+
+        await self._indego_client.update_predictive_calendar()
+
+        calendar = getattr(self._indego_client, "predictive_calendar", None)
+
+        if ENTITY_PREDICTIVE_CALENDAR_SLOTS not in self.entities:
+            return
+
+        mowing_mode = getattr(
+            self._indego_client.generic_data,
+            "mowing_mode_description",
+            None,
+        )
+
+        smartmowing_enabled = str(mowing_mode).lower() == "smartmowing"
+
+        slots_by_day = _calendar_slots_by_day(calendar)
+        today_name = _today_calendar_day_name()
+        today_slots = _today_calendar_slots(slots_by_day)
+
+        sensor = self.entities[ENTITY_PREDICTIVE_CALENDAR_SLOTS]
+
+        if not smartmowing_enabled:
+            sensor.state = "off"
+        else:
+            sensor.state = ", ".join(today_slots) if today_slots else "off"
+
+        sensor.set_attributes(
+            {
+                "last_updated": last_updated_now(),
+                "smartmowing_enabled": smartmowing_enabled,
+                "today_slot_1": slots_by_day.get(f"{today_name}_slot_1"),
+                "today_slot_2": slots_by_day.get(f"{today_name}_slot_2"),
+                **slots_by_day,
+            }
+        )
+
+    async def _update_calendar(self):
+        """Update calendar data / planned mowing slots."""
+        _LOGGER.debug("Fetching calendar from Bosch API")
+
+        await self._indego_client.update_calendar()
+
+        calendar = getattr(self._indego_client, "calendar", None)
+
+        if ENTITY_CALENDAR_SLOTS not in self.entities:
+            return
+
+        slots_by_day = _calendar_slots_by_day(calendar)
+        today_name = _today_calendar_day_name()
+        today_slots = _today_calendar_slots(slots_by_day)
+
+        sensor = self.entities[ENTITY_CALENDAR_SLOTS]
+        sensor.state = ", ".join(today_slots) if today_slots else "off"
+
+        sensor.set_attributes(
+            {
+                "last_updated": last_updated_now(),
+                "today_slot_1": slots_by_day.get(f"{today_name}_slot_1"),
+                "today_slot_2": slots_by_day.get(f"{today_name}_slot_2"),
+                **slots_by_day,
+            }
+        )
 
     def set_online_state(self, online: bool):
         current_is_online = self.entities[ENTITY_ONLINE].state
@@ -1497,18 +1871,31 @@ class IndegoHub:
                     if ENTITY_MOWER_SVG_Y in self.entities:
                         self.entities[ENTITY_MOWER_SVG_Y].state = svg_y
 
+
+#                    current_state_code = self._indego_client.state.state
+#                    is_mowing = 500 <= current_state_code <= 799
+#                    now = datetime.now()
+
                     current_state_code = self._indego_client.state.state
-                    is_mowing = 500 <= current_state_code <= 799
+                    stuck_detection_allowed = current_state_code not in self.STUCK_IGNORED_STATES
+                    is_mowing = stuck_detection_allowed and (
+                        500 <= current_state_code <= 799
+                        or current_state_code in {768, 769, 770, 771, 772, 773, 774, 775, 776}
+                    )
                     now = datetime.now()
+
+                    if not stuck_detection_allowed:
+                        _LOGGER.debug(
+                            "Stuck detection: state=%s detail=%s allowed=%s",
+                            current_state_code,
+                            self._indego_client.state_description_detail,
+                            stuck_detection_allowed,
+                        )
 
                     # Track mowing session start
                     if is_mowing and self._mowing_session_start_time is None:
                         self._mowing_session_start_time = now
-                        # Reset position tracking for new session to avoid false stuck detection
-                        self._last_position_change_time = now
-                        self._last_svg_x = svg_x
-                        self._last_svg_y = svg_y
-                        _LOGGER.debug("Mowing session started - resetting position tracking for stuck detection grace period")
+                        _LOGGER.debug("Mowing session started - activating stuck detection after grace period")
                     elif not is_mowing and self._mowing_session_start_time is not None:
                         self._mowing_session_start_time = None
 
@@ -1614,6 +2001,7 @@ class IndegoHub:
         return self._indego_client.generic_data
 
     async def _update_alerts(self):
+
         await self._indego_client.update_alerts()
 
         # Show "Problem" only if there are unread alerts

--- a/custom_components/indego/const.py
+++ b/custom_components/indego/const.py
@@ -29,6 +29,13 @@ CONF_POLLING: Final = "polling"
 CONF_ENABLED_BY_DEFAULT: Final = "enabled_by_default"
 CONF_ENTITY_CATEGORY: Final = "entity_category"
 
+CONF_CALENDAR_TYPE: Final = "calendar_type"
+CONF_DAY: Final = "day"
+CONF_SLOT: Final = "slot"
+CONF_ENABLED: Final = "enabled"
+CONF_START: Final = "start"
+CONF_END: Final = "end"
+
 CONF_SERVICE: Final = "service"
 CONF_SERVICE_DATA: Final = "service_data"
 
@@ -104,6 +111,14 @@ ENTITY_SMARTMOW_SCHEDULE: Final = "smartmow_schedule"
 SERVICE_NAME_SET_LOCATION: Final = "set_smart_mowing_location"
 SERVICE_NAME_CONFIGURE_SETUP: Final = "configure_smart_mowing"
 SERVICE_NAME_RESET_SMART_MOWING: Final = "reset_smart_mowing"
+
+# Calendar
+ENTITY_PREDICTIVE_CALENDAR_SLOTS: Final = "predictive_calendar_slots"
+ENTITY_CALENDAR_SLOTS: Final = "calendar_slots"
+
+# Calendar services
+SERVICE_NAME_SET_CALENDAR_SLOT: Final = "set_calendar_slot"
+
 
 DELETE_ALERTS_BATCH_DELAY_SECONDS: Final = 10
 DELETE_ALERTS_BATCH_MAX_ROUNDS: Final = 20

--- a/custom_components/indego/services.yaml
+++ b/custom_components/indego/services.yaml
@@ -2,14 +2,19 @@ command:
   description: Sends a control command to the mower. Valid commands are "mow" (start mowing), "returnToDock" (return to charging station) and "pause" (pause mowing).
   fields:
     mower_serial:
+      name: Serialnumber
       description: Serial number of the mower. Only required if multiple mowers are configured.
       example: '"012345789"'
       required: false
+      selector:
+        text: {}
     command:
+      name: Command
       description: Command to send to the mower.
       required: true
       selector:
         select:
+          translation_key: command_options
           options:
             - "mow"
             - "returnToDock"
@@ -18,84 +23,150 @@ smartmowing:
   description: Enables or disables the SmartMowing feature, which automatically adjusts the mowing schedule based on weather conditions and lawn growth.
   fields:
     mower_serial:
+      name: Serialnumber
       description: Serial number of the mower. Only required if multiple mowers are configured.
       example: '"012345789"'
       required: false
+      selector:
+        text: {}
     enable:
+      name: Activate/Deactivate
       description: Sets the SmartMowing state. Use "true" to enable or "false" to disable the feature.
       example: "true"
       required: true
+      selector:
+        boolean: {}
 delete_alert:
   description: Deletes a specific alert by its index. Index 0 refers to the most recent alert.
   fields:
     mower_serial:
+      name: Serialnumber
       description: Serial number of the mower. Only required if multiple mowers are configured.
       example: '"0123456789"'
       required: false
+      selector:
+        text: {}
     alert_index:
+      name: Alert index
       description: Index of the alert to delete. 0 = most recent, 1 = second most recent, and so on.
       example: "0"
       required: true
+      selector:
+        text: {}
 delete_alert_all:
   description: Deletes all existing alerts for the mower at once.
   fields:
     mower_serial:
+      name: Serialnumber
       description: Serial number of the mower. Only required if multiple mowers are configured.
       example: '"0123456789"'
       required: false
+      selector:
+        text: {}
 read_alert:
   description: Marks a specific alert as read by its index. Index 0 refers to the most recent alert.
   fields:
     mower_serial:
+      name: Serialnumber
       description: Serial number of the mower. Only required if multiple mowers are configured.
       example: '"0123456789"'
       required: false
+      selector:
+        text: {}
     alert_index:
+      name: Alert Index
       description: Index of the alert to mark as read. 0 = most recent, 1 = second most recent, and so on.
       example: "0"
       required: true
+      selector:
+        text: {}
 read_alert_all:
   description: Marks all existing alerts for the mower as read.
   fields:
     mower_serial:
+      name: Serialnumber
       description: Serial number of the mower. Only required if multiple mowers are configured.
       example: '"0123456789"'
       required: false
+      selector:
+        text: {}
 download_map:
   description: Downloads the current mowing map from the Bosch Cloud API and saves it locally as "www/indego_map_base.svg". The map reflects the most recently recorded mowing route.
   fields:
     mower_serial:
+      name: Serialnumber
       description: Serial number of the mower. Only required if multiple mowers are configured.
       example: '"0123456789"'
       required: false
+      selector:
+        text: {}
 set_calendar_slot:
   description: Set a calender slot when you use the manual calendar instead of SmartMowing.
   fields:
     mower_serial:
+      name: Serialnumber
       description: Serial number of the mower. Only required if multiple mowers are configured.
       example: '"0123456789"'
       required: false
+      selector:
+        text: {}
     calendar_type:
+      name: Calendar type
       description: Type of calendar to use. Use "calendar for manual calendar or "predictive" for the forbidden time slots in SmartMowing mode.
       example: "calendar"
       required: false
+      default: "calendar"
+      selector:
+        select:
+          translation_key: calendar_type_options
+          options:
+            - "calendar"
+            - "predictive"
     day:
+      name: Day
       description: Which day to configure.
       example: "monday"
       required: true
+      selector:
+        select:
+          translation_key: day_options
+          options:
+            - "monday"
+            - "tuesday"
+            - "wednesday"
+            - "thursday"
+            - "friday"
+            - "saturday"
+            - "sunday"
     slot:
+      name: Slot
       description: Which Slot of the selected day should be configured (1 or 2).
       example: "1"
       required: true
+      selector:
+        number:
+          min: 1
+          max: 2
+          step: 1
+          mode: box
     enabled:
+      name: Activate/Deactivate
       description: Should the selected slot be enabled or disabled.
       example: "true"
       required: false
+      selector:
+        boolean: {}
     start:
-      description: Set Start Time of the selected slot and day. Only needed if you want to enable a slot.
+      name: Start time
+      description: Set Start Time of the selected slot and day. Only needed if you want to enable a slot. Only hour and minute will be used.
       example: '"08:00"'
       required: false
+      selector:
+        time: {}
     end:
-      description: Set End Time of the selected slot and day. Only needed if you want to enable a slot.
+      name: End time
+      description: Set End Time of the selected slot and day. Only needed if you want to enable a slot. Only hour and minute will be used.
       example: '"20:00"'
       required: false
+      selector:
+        time: {}

--- a/custom_components/indego/services.yaml
+++ b/custom_components/indego/services.yaml
@@ -68,3 +68,34 @@ download_map:
       description: Serial number of the mower. Only required if multiple mowers are configured.
       example: '"0123456789"'
       required: false
+set_calendar_slot:
+  description: Set a calender slot when you use the manual calendar instead of SmartMowing.
+  fields:
+    mower_serial:
+      description: Serial number of the mower. Only required if multiple mowers are configured.
+      example: '"0123456789"'
+      required: false
+    calendar_type:
+      description: Type of calendar to use. Use "calendar for manual calendar or "predictive" for the forbidden time slots in SmartMowing mode.
+      example: "calendar"
+      required: false
+    day:
+      description: Which day to configure.
+      example: "monday"
+      required: true
+    slot:
+      description: Which Slot of the selected day should be configured (1 or 2).
+      example: "1"
+      required: true
+    enabled:
+      description: Should the selected slot be enabled or disabled.
+      example: "true"
+      required: false
+    start:
+      description: Set Start Time of the selected slot and day. Only needed if you want to enable a slot.
+      example: '"08:00"'
+      required: false
+    end:
+      description: Set End Time of the selected slot and day. Only needed if you want to enable a slot.
+      example: '"20:00"'
+      required: false

--- a/custom_components/indego/translations/da.json
+++ b/custom_components/indego/translations/da.json
@@ -301,26 +301,58 @@
             "description": "Rediger en kalender-slot (ændr tider, aktivér eller deaktivér)",
             "fields": {
                 "mower_serial": {
+                    "name": "Serienummer",
                     "description": "Serienummer på plæneklipperen. Kun nødvendig, hvis der er konfigureret flere plæneklippere."
                 },
                 "calendar_type": {
+                    "name": "Kalendertype",
                     "description": "Vælg kalender ('calendar' for manuel kalender eller 'predictive' for deaktiverede tidsrum i SmartMowing-tilstand)."
                 },
                 "day": {
+                    "name": "Dag",
                     "description": "Navnet på den ugedag, der skal konfigureres."
                 },
                 "slot": {
+                    "name": "Tidsslot",
                     "description": "Hvilken tidsslot skal ændres (1 eller 2)."
                 },
                 "enabled": {
+                    "name": "Aktivér/deaktivér",
                     "description": "Aktivér eller deaktivér den valgte dag/slot."
                 },
                 "start": {
-                    "description": "Starttidspunkt for den valgte slot. Kun nødvendigt, hvis tidsslotten skal aktiveres."
+                    "name": "Start",
+                    "description": "Starttidspunkt for den valgte slot. Kun nødvendigt hvis slotten skal aktiveres. Kun timer og minutter anvendes."
                 },
                 "end": {
-                    "description": "Sluttidspunkt for den valgte slot. Kun nødvendigt, hvis tidsslotten skal aktiveres."
+                    "name": "Slut",
+                    "description": "Sluttidspunkt for den valgte slot. Kun nødvendigt hvis slotten skal aktiveres. Kun timer og minutter anvendes."
                 }
+            }
+        },
+    "selector": {
+        "calendar_type_options": {
+            "options": {
+                "calendar": "Manuel kalender",
+                "predictive": "SmartMowing-spærretider"
+            }
+        },
+        "day_options": {
+            "options": {
+                "monday": "Mandag",
+                "tuesday": "Tirsdag",
+                "wednesday": "Onsdag",
+                "thursday": "Torsdag",
+                "friday": "Fredag",
+                "saturday": "Lørdag",
+                "sunday": "Søndag"
+            }
+        },
+        "command_options": {
+            "options": {
+                "mow": "Klip græs",
+                "returnToDock": "Tilbage til ladestationen",
+                "pause": "Pause"
             }
         }
     },

--- a/custom_components/indego/translations/da.json
+++ b/custom_components/indego/translations/da.json
@@ -295,6 +295,33 @@
                     "description": "Græsslåmaskine serienummer. Kun nødvendigt, når du har konfigureret flere græsslåmaskiner."
                 }
             }
+        },
+        "set_calendar_slot": {
+            "name": "Aktivér/deaktivér kalender-slot",
+            "description": "Rediger en kalender-slot (ændr tider, aktivér eller deaktivér)",
+            "fields": {
+                "mower_serial": {
+                    "description": "Serienummer på plæneklipperen. Kun nødvendig, hvis der er konfigureret flere plæneklippere."
+                },
+                "calendar_type": {
+                    "description": "Vælg kalender ('calendar' for manuel kalender eller 'predictive' for deaktiverede tidsrum i SmartMowing-tilstand)."
+                },
+                "day": {
+                    "description": "Navnet på den ugedag, der skal konfigureres."
+                },
+                "slot": {
+                    "description": "Hvilken tidsslot skal ændres (1 eller 2)."
+                },
+                "enabled": {
+                    "description": "Aktivér eller deaktivér den valgte dag/slot."
+                },
+                "start": {
+                    "description": "Starttidspunkt for den valgte slot. Kun nødvendigt, hvis tidsslotten skal aktiveres."
+                },
+                "end": {
+                    "description": "Sluttidspunkt for den valgte slot. Kun nødvendigt, hvis tidsslotten skal aktiveres."
+                }
+            }
         }
     },
     "issues": {

--- a/custom_components/indego/translations/de.json
+++ b/custom_components/indego/translations/de.json
@@ -192,6 +192,240 @@
             },
             "battery_discharge": {
                 "name": "Batterieentladung"
+            },
+            "predictive_calendar_slots": {
+                "name": "SmartMowing Sperrzeiten",
+                "state_attributes": {
+                    "today_slot_1": {
+                        "name": "Heute Slot 1",
+                        "state": {
+                            "not enabled": "Nicht aktiviert",
+                            "not configured": "Nicht konfiguriert"
+                        }
+                    },
+                    "today_slot_2": {
+                        "name": "Heute Slot 2",
+                        "state": {
+                            "not enabled": "Nicht aktiviert",
+                            "not configured": "Nicht konfiguriert"
+                        }
+                    },
+                    "monday_slot_1": {
+                        "name": "Montag Slot 1",
+                        "state": {
+                            "not enabled": "Nicht aktiviert",
+                            "not configured": "Nicht konfiguriert"
+                        }
+                    },
+                    "monday_slot_2": {
+                        "name": "Montag Slot 2",
+                        "state": {
+                            "not enabled": "Nicht aktiviert",
+                            "not configured": "Nicht konfiguriert"
+                        }
+                    },
+                    "tuesday_slot_1": {
+                        "name": "Dienstag Slot 1",
+                        "state": {
+                            "not enabled": "Nicht aktiviert",
+                            "not configured": "Nicht konfiguriert"
+                        }
+                    },
+                    "tuesday_slot_2": {
+                        "name": "Dienstag Slot 2",
+                        "state": {
+                            "not enabled": "Nicht aktiviert",
+                            "not configured": "Nicht konfiguriert"
+                        }
+                    },
+                    "wednesday_slot_1": {
+                        "name": "Mittwoch Slot 1",
+                        "state": {
+                            "not enabled": "Nicht aktiviert",
+                            "not configured": "Nicht konfiguriert"
+                        }
+                    },
+                    "wednesday_slot_2": {
+                        "name": "Mittwoch Slot 2",
+                        "state": {
+                            "not enabled": "Nicht aktiviert",
+                            "not configured": "Nicht konfiguriert"
+                        }
+                    },
+                    "thursday_slot_1": {
+                        "name": "Donnerstag Slot 1",
+                        "state": {
+                            "not enabled": "Nicht aktiviert",
+                            "not configured": "Nicht konfiguriert"
+                        }
+                    },
+                    "thursday_slot_2": {
+                        "name": "Donnerstag Slot 2",
+                        "state": {
+                            "not enabled": "Nicht aktiviert",
+                            "not configured": "Nicht konfiguriert"
+                        }
+                    },
+                    "friday_slot_1": {
+                        "name": "Freitag Slot 1",
+                        "state": {
+                            "not enabled": "Nicht aktiviert",
+                            "not configured": "Nicht konfiguriert"
+                        }
+                    },
+                    "friday_slot_2": {
+                        "name": "Freitag Slot 2",
+                        "state": {
+                            "not enabled": "Nicht aktiviert",
+                            "not configured": "Nicht konfiguriert"
+                        }
+                    },
+                    "saturday_slot_1": {
+                        "name": "Samstag Slot 1",
+                        "state": {
+                            "not enabled": "Nicht aktiviert",
+                            "not configured": "Nicht konfiguriert"
+                        }
+                    },
+                    "saturday_slot_2": {
+                        "name": "Samstag Slot 2",
+                        "state": {
+                            "not enabled": "Nicht aktiviert",
+                            "not configured": "Nicht konfiguriert"
+                        }
+                    },
+                    "sunday_slot_1": {
+                        "name": "Sonntag Slot 1",
+                        "state": {
+                            "not enabled": "Nicht aktiviert",
+                            "not configured": "Nicht konfiguriert"
+                        }
+                    },
+                    "sunday_slot_2": {
+                        "name": "Sonntag Slot 2",
+                        "state": {
+                            "not enabled": "Nicht aktiviert",
+                            "not configured": "Nicht konfiguriert"
+                        }
+                    }
+                }
+            },
+            "calendar_slots": {
+                "name": "Geplante Mähzeiten",
+                "state_attributes": {
+                    "today_slot_1": {
+                        "name": "Heute Slot 1",
+                        "state": {
+                            "not enabled": "Nicht aktiviert",
+                            "not configured": "Nicht konfiguriert"
+                        }
+                    },
+                    "today_slot_2": {
+                        "name": "Heute Slot 2",
+                        "state": {
+                            "not enabled": "Nicht aktiviert",
+                            "not configured": "Nicht konfiguriert"
+                        }
+                    },
+                    "monday_slot_1": {
+                        "name": "Montag Slot 1",
+                        "state": {
+                            "not enabled": "Nicht aktiviert",
+                            "not configured": "Nicht konfiguriert"
+                        }
+                    },
+                    "monday_slot_2": {
+                        "name": "Montag Slot 2",
+                        "state": {
+                            "not enabled": "Nicht aktiviert",
+                            "not configured": "Nicht konfiguriert"
+                        }
+                    },
+                    "tuesday_slot_1": {
+                        "name": "Dienstag Slot 1",
+                        "state": {
+                            "not enabled": "Nicht aktiviert",
+                            "not configured": "Nicht konfiguriert"
+                        }
+                    },
+                    "tuesday_slot_2": {
+                        "name": "Dienstag Slot 2",
+                        "state": {
+                            "not enabled": "Nicht aktiviert",
+                            "not configured": "Nicht konfiguriert"
+                        }
+                    },
+                    "wednesday_slot_1": {
+                        "name": "Mittwoch Slot 1",
+                        "state": {
+                            "not enabled": "Nicht aktiviert",
+                            "not configured": "Nicht konfiguriert"
+                        }
+                    },
+                    "wednesday_slot_2": {
+                        "name": "Mittwoch Slot 2",
+                        "state": {
+                            "not enabled": "Nicht aktiviert",
+                            "not configured": "Nicht konfiguriert"
+                        }
+                    },
+                    "thursday_slot_1": {
+                        "name": "Donnerstag Slot 1",
+                        "state": {
+                            "not enabled": "Nicht aktiviert",
+                            "not configured": "Nicht konfiguriert"
+                        }
+                    },
+                    "thursday_slot_2": {
+                        "name": "Donnerstag Slot 2",
+                        "state": {
+                            "not enabled": "Nicht aktiviert",
+                            "not configured": "Nicht konfiguriert"
+                        }
+                    },
+                    "friday_slot_1": {
+                        "name": "Freitag Slot 1",
+                        "state": {
+                            "not enabled": "Nicht aktiviert",
+                            "not configured": "Nicht konfiguriert"
+                        }
+                    },
+                    "friday_slot_2": {
+                        "name": "Freitag Slot 2",
+                        "state": {
+                            "not enabled": "Nicht aktiviert",
+                            "not configured": "Nicht konfiguriert"
+                        }
+                    },
+                    "saturday_slot_1": {
+                        "name": "Samstag Slot 1",
+                        "state": {
+                            "not enabled": "Nicht aktiviert",
+                            "not configured": "Nicht konfiguriert"
+                        }
+                    },
+                    "saturday_slot_2": {
+                        "name": "Samstag Slot 2",
+                        "state": {
+                            "not enabled": "Nicht aktiviert",
+                            "not configured": "Nicht konfiguriert"
+                        }
+                    },
+                    "sunday_slot_1": {
+                        "name": "Sonntag Slot 1",
+                        "state": {
+                            "not enabled": "Nicht aktiviert",
+                            "not configured": "Nicht konfiguriert"
+                        }
+                    },
+                    "sunday_slot_2": {
+                        "name": "Sonntag Slot 2",
+                        "state": {
+                            "not enabled": "Nicht aktiviert",
+                            "not configured": "Nicht konfiguriert"
+                        }
+                    }
+                }
             }
         },
         "camera": {
@@ -293,6 +527,33 @@
             "fields": {
                 "mower_serial": {
                     "description": "Seriennummer des Mähroboters. Wird nur benötigt, wenn mehrere Mähroboter eingerichtet sind."
+                }
+            }
+        },
+        "set_calendar_slot": {
+            "name": "Kalender Slot aktivieren/deaktivieren",
+            "description": "Einen Kalender Slot verändern (Zeiten ändern, aktivieren oder deaktivieren)",
+            "fields": {
+                "mower_serial": {
+                    "description": "Seriennummer des Mähroboters. Wird nur benötigt, wenn mehrere Mähroboter eingerichtet sind."
+                },
+                "calendar_type": {
+                    "description": "Kalender auswählen ('calendar' für manuellen Kalender oder 'predictive' für deaktivierte Zeiten im SmartMowing Modus)."
+                },
+                "day": {
+                    "description": "Name des Wochentags der konfiguriert werden soll"
+                },
+                "slot": {
+                    "description": "Welcher Zeitslot soll geändert werden (1 oder 2)"
+                },
+                "enabled": {
+                    "description": "Gewhälten Tag/Slot aktivieren/deaktivieren"
+                },
+                "start": {
+                    "description": "Startzeit des gewählten Slots. Wird nur benötigt wenn ein Zeitslot aktiviert werden soll."
+                },
+                "end": {
+                    "description": "Endzeit des gewählten Slots. Wird nur benötigt wenn ein Zeitslot aktiviert werden soll."
                 }
             }
         }

--- a/custom_components/indego/translations/de.json
+++ b/custom_components/indego/translations/de.json
@@ -459,6 +459,7 @@
             "description": "Befehle an den Mähroboter senden. Wählen Sie einen Befehl aus.",
             "fields": {
                 "mower_serial": {
+                    "name": "Seriennummer",
                     "description": "Seriennummer des Mähroboters. Wird nur benötigt, wenn mehrere Mähroboter eingerichtet sind."
                 },
                 "command": {
@@ -472,9 +473,11 @@
             "description": "SmartMowing aktivieren oder deaktivieren. Mögliche Werte sind true oder false.",
             "fields": {
                 "mower_serial": {
+                    "name": "Seriennummer",
                     "description": "Seriennummer des Mähroboters. Wird nur benötigt, wenn mehrere Mähroboter eingerichtet sind."
                 },
                 "enable": {
+                    "name": "Aktivieren/Deaktivieren",
                     "description": "SmartMowing aktivieren."
                 }
             }
@@ -484,9 +487,11 @@
             "description": "Löscht den ausgewählten Fehler.",
             "fields": {
                 "mower_serial": {
+                    "name": "Seriennummer",
                     "description": "Seriennummer des Mähroboters. Wird nur benötigt, wenn mehrere Mähroboter eingerichtet sind."
                 },
                 "alert_index": {
+                    "name": "Fehler Index",
                     "description": "Den ausgewählten Fehler löschen. Mit 0 wird der letzte/aktuellste Fehler gelöscht."
                 }
             }
@@ -496,6 +501,7 @@
             "description": "Löscht alle Fehler.",
             "fields": {
                 "mower_serial": {
+                    "name": "Seriennummer",
                     "description": "Seriennummer des Mähroboters. Wird nur benötigt, wenn mehrere Mähroboter eingerichtet sind."
                 }
             }
@@ -505,9 +511,11 @@
             "description": "Markiert den ausgewählten Fehler als gelesen.",
             "fields": {
                 "mower_serial": {
+                    "name": "Seriennummer",
                     "description": "Seriennummer des Mähroboters. Wird nur benötigt, wenn mehrere Mähroboter eingerichtet sind."
                 },
                 "alert_index": {
+                    "name": "Fehler Index",
                     "description": "Den ausgewählten Fehler als gelesen markieren. Mit 0 wird der letzte/aktuellste Fehler ausgewählt."
                 }
             }
@@ -517,6 +525,7 @@
             "description": "Markiert alle Fehler als gelesen.",
             "fields": {
                 "mower_serial": {
+                    "name": "Seriennummer",
                     "description": "Seriennummer des Mähroboters. Wird nur benötigt, wenn mehrere Mähroboter eingerichtet sind."
                 }
             }
@@ -526,6 +535,7 @@
             "description": "Lädt die aktuelle Mähkarte von der Bosch Cloud API herunter und speichert diese lokal unter \"www/indego_map_base.svg\". Die Karte zeigt die zuletzt aufgezeichnete Mähroute.",
             "fields": {
                 "mower_serial": {
+                    "name": "Seriennummer",
                     "description": "Seriennummer des Mähroboters. Wird nur benötigt, wenn mehrere Mähroboter eingerichtet sind."
                 }
             }
@@ -535,26 +545,59 @@
             "description": "Einen Kalender Slot verändern (Zeiten ändern, aktivieren oder deaktivieren)",
             "fields": {
                 "mower_serial": {
+                    "name": "Seriennummer",
                     "description": "Seriennummer des Mähroboters. Wird nur benötigt, wenn mehrere Mähroboter eingerichtet sind."
                 },
                 "calendar_type": {
+                    "name": "Kalender Typ",
                     "description": "Kalender auswählen ('calendar' für manuellen Kalender oder 'predictive' für deaktivierte Zeiten im SmartMowing Modus)."
                 },
                 "day": {
+                    "name": "Tag",
                     "description": "Name des Wochentags der konfiguriert werden soll"
                 },
                 "slot": {
+                    "name": "Zeitfenster",
                     "description": "Welcher Zeitslot soll geändert werden (1 oder 2)"
                 },
                 "enabled": {
+                    "name": "Aktivieren/Deaktivieren",
                     "description": "Gewhälten Tag/Slot aktivieren/deaktivieren"
                 },
                 "start": {
-                    "description": "Startzeit des gewählten Slots. Wird nur benötigt wenn ein Zeitslot aktiviert werden soll."
+                    "name": "Start",
+                    "description": "Startzeit des gewählten Slots. Wird nur benötigt wenn ein Zeitslot aktiviert werden soll. Nur Stunden und Minuten werden übernommen."
                 },
                 "end": {
-                    "description": "Endzeit des gewählten Slots. Wird nur benötigt wenn ein Zeitslot aktiviert werden soll."
+                    "name": "Ende",
+                    "description": "Endzeit des gewählten Slots. Wird nur benötigt wenn ein Zeitslot aktiviert werden soll. Nur Stunden und Minuten werden übernommen."
                 }
+            }
+        }
+    },
+    "selector": {
+        "calendar_type_options": {
+            "options": {
+                "calendar": "Manueller Kalender",
+                "predictive": "SmartMowing Sperrzeiten"
+            }
+        },
+        "day_options": {
+            "options": {
+                "monday": "Montag",
+                "tuesday": "Dienstag",
+                "wednesday": "Mittwoch",
+                "thursday": "Donnerstag",
+                "friday": "Freitag",
+                "saturday": "Samstag",
+                "sunday": "Sonntag"
+            }
+        },
+        "command_options": {
+            "options": {
+                "mow": "Mähen",
+                "returnToDock": "Zurück zur Docking Station",
+                "pause": "Pause"
             }
         }
     },

--- a/custom_components/indego/translations/en.json
+++ b/custom_components/indego/translations/en.json
@@ -297,30 +297,57 @@
             }
         },
         "set_calendar_slot": {
-            "name": "Activar/desactivar intervalo del calendario",
+            "name": "Activate/Deactivate calendar slot",
             "description": "Set a calender slot when you use the manual calendar instead of SmartMowing.",
             "fields": {
                 "mower_serial": {
+                    "name": "Serialnumber",
                     "description": "Serial number of the mower. Only required if multiple mowers are configured."
                 },
                 "calendar_type": {
+                    "name": "Calendar Type",
                     "description": "Type of calendar to use. Use 'calendar' for manual calendar or 'predictive' for the forbidden time slots in SmartMowing mode."
                 },
                 "day": {
-                    "description": "Which day to configure."
+                    "name": "Day",
+                    "description": "Which day to configure.",
+                    "example": "Montag"
                 },
                 "slot": {
+                    "name": "Time slot",
                     "description": "Which Slot of the selected day should be configured (1 or 2)."
                 },
                 "enabled": {
+                    "name": "Activate/Deactivate",
                     "description": "Should the selected slot be enabled or disabled."
                 },
                 "start": {
+                    "name": "Start",
                     "description": "Set Start Time of the selected slot and day. Only needed if you want to enable a slot."
                 },
                 "end": {
+                    "name": "End",
                     "description": "Set End Time of the selected slot and day. Only needed if you want to enable a slot."
                 }
+            }
+        }
+    },
+    "selector": {
+        "calendar_type_options": {
+            "options": {
+                "calendar": "Manual Calendar",
+                "predictive": "SmartMowing predicted slots"
+            }
+        },
+        "day_options": {
+            "options": {
+                "monday": "Monday",
+                "tuesday": "Tuesday",
+                "wednesday": "Wednesday",
+                "thursday": "Thursday",
+                "friday": "Friday",
+                "saturday": "saturday",
+                "sunday": "Sunday"
             }
         }
     },

--- a/custom_components/indego/translations/en.json
+++ b/custom_components/indego/translations/en.json
@@ -295,6 +295,33 @@
                     "description": "Mower serial. Only needed when you have configured multiple mowers."
                 }
             }
+        },
+        "set_calendar_slot": {
+            "name": "Activar/desactivar intervalo del calendario",
+            "description": "Set a calender slot when you use the manual calendar instead of SmartMowing.",
+            "fields": {
+                "mower_serial": {
+                    "description": "Serial number of the mower. Only required if multiple mowers are configured."
+                },
+                "calendar_type": {
+                    "description": "Type of calendar to use. Use 'calendar' for manual calendar or 'predictive' for the forbidden time slots in SmartMowing mode."
+                },
+                "day": {
+                    "description": "Which day to configure."
+                },
+                "slot": {
+                    "description": "Which Slot of the selected day should be configured (1 or 2)."
+                },
+                "enabled": {
+                    "description": "Should the selected slot be enabled or disabled."
+                },
+                "start": {
+                    "description": "Set Start Time of the selected slot and day. Only needed if you want to enable a slot."
+                },
+                "end": {
+                    "description": "Set End Time of the selected slot and day. Only needed if you want to enable a slot."
+                }
+            }
         }
     },
     "issues": {

--- a/custom_components/indego/translations/es.json
+++ b/custom_components/indego/translations/es.json
@@ -301,26 +301,59 @@
             "description": "Modificar un intervalo del calendario (cambiar horarios, activar o desactivar)",
             "fields": {
                 "mower_serial": {
+                    "name": "Número de serie",
                     "description": "Número de serie del cortacésped. Solo es necesario si hay varios cortacéspedes configurados."
                 },
                 "calendar_type": {
+                    "name": "Tipo de calendario",
                     "description": "Selecciona el calendario ('calendar' para el calendario manual o 'predictive' para los períodos desactivados en el modo SmartMowing)."
                 },
                 "day": {
+                    "name": "Día",
                     "description": "Nombre del día de la semana que se va a configurar."
                 },
                 "slot": {
+                    "name": "Intervalo de tiempo",
                     "description": "Qué intervalo de tiempo se debe modificar (1 o 2)."
                 },
                 "enabled": {
+                    "name": "Activar/desactivar",
                     "description": "Activar o desactivar el día/intervalo seleccionado."
                 },
                 "start": {
-                    "description": "Hora de inicio del intervalo seleccionado. Solo es necesaria si se va a activar un intervalo de tiempo."
+                    "name": "Inicio",
+                    "description": "Hora de inicio del intervalo seleccionado. Solo es necesaria si se va a activar un intervalo. Solo se utilizan horas y minutos."
                 },
                 "end": {
-                    "description": "Hora de finalización del intervalo seleccionado. Solo es necesaria si se va a activar un intervalo de tiempo."
+                    "name": "Fin",
+                    "description": "Hora de finalización del intervalo seleccionado. Solo es necesaria si se va a activar un intervalo. Solo se utilizan horas y minutos."
                 }
+            }
+        }
+    },
+    "selector": {
+        "calendar_type_options": {
+            "options": {
+                "calendar": "Calendario manual",
+                "predictive": "Períodos bloqueados de SmartMowing"
+            }
+        },
+        "day_options": {
+            "options": {
+                "monday": "Lunes",
+                "tuesday": "Martes",
+                "wednesday": "Miércoles",
+                "thursday": "Jueves",
+                "friday": "Viernes",
+                "saturday": "Sábado",
+                "sunday": "Domingo"
+            }
+        },
+        "command_options": {
+            "options": {
+                "mow": "Cortar césped",
+                "returnToDock": "Volver a la estación de carga",
+                "pause": "Pausa"
             }
         }
     },

--- a/custom_components/indego/translations/es.json
+++ b/custom_components/indego/translations/es.json
@@ -295,6 +295,33 @@
                     "description": "Número de serie del robot. Solo es necesario cuando tiene configurados varios robots cortacéspedes."
                 }
             }
+        },
+        "set_calendar_slot": {
+            "name": "Activar/desactivar intervalo del calendario",
+            "description": "Modificar un intervalo del calendario (cambiar horarios, activar o desactivar)",
+            "fields": {
+                "mower_serial": {
+                    "description": "Número de serie del cortacésped. Solo es necesario si hay varios cortacéspedes configurados."
+                },
+                "calendar_type": {
+                    "description": "Selecciona el calendario ('calendar' para el calendario manual o 'predictive' para los períodos desactivados en el modo SmartMowing)."
+                },
+                "day": {
+                    "description": "Nombre del día de la semana que se va a configurar."
+                },
+                "slot": {
+                    "description": "Qué intervalo de tiempo se debe modificar (1 o 2)."
+                },
+                "enabled": {
+                    "description": "Activar o desactivar el día/intervalo seleccionado."
+                },
+                "start": {
+                    "description": "Hora de inicio del intervalo seleccionado. Solo es necesaria si se va a activar un intervalo de tiempo."
+                },
+                "end": {
+                    "description": "Hora de finalización del intervalo seleccionado. Solo es necesaria si se va a activar un intervalo de tiempo."
+                }
+            }
         }
     },
     "issues": {

--- a/custom_components/indego/translations/fr.json
+++ b/custom_components/indego/translations/fr.json
@@ -301,26 +301,59 @@
             "description": "Modifier un créneau du calendrier (changer les horaires, activer ou désactiver)",
             "fields": {
                 "mower_serial": {
+                    "name": "Numéro de série",
                     "description": "Numéro de série de la tondeuse. Nécessaire uniquement si plusieurs tondeuses sont configurées."
                 },
                 "calendar_type": {
+                    "name": "Type de calendrier",
                     "description": "Sélectionnez le calendrier ('calendar' pour le calendrier manuel ou 'predictive' pour les périodes désactivées en mode SmartMowing)."
                 },
                 "day": {
+                    "name": "Jour",
                     "description": "Nom du jour de la semaine à configurer."
                 },
                 "slot": {
-                    "description": "Créneau horaire à modifier (1 ou 2)."
+                    "name": "Créneau horaire",
+                    "description": "Créneau à modifier (1 ou 2)."
                 },
                 "enabled": {
+                    "name": "Activer/désactiver",
                     "description": "Activer ou désactiver le jour/créneau sélectionné."
                 },
                 "start": {
-                    "description": "Heure de début du créneau sélectionné. Requise uniquement lorsqu’un créneau doit être activé."
+                    "name": "Début",
+                    "description": "Heure de début du créneau sélectionné. Requise uniquement lorsqu’un créneau doit être activé. Seules les heures et les minutes sont utilisées."
                 },
                 "end": {
-                    "description": "Heure de fin du créneau sélectionné. Requise uniquement lorsqu’un créneau doit être activé."
+                    "name": "Fin",
+                    "description": "Heure de fin du créneau sélectionné. Requise uniquement lorsqu’un créneau doit être activé. Seules les heures et les minutes sont utilisées."
                 }
+            }
+        }
+    },
+    "selector": {
+        "calendar_type_options": {
+            "options": {
+                "calendar": "Calendrier manuel",
+                "predictive": "Périodes bloquées SmartMowing"
+            }
+        },
+        "day_options": {
+            "options": {
+                "monday": "Lundi",
+                "tuesday": "Mardi",
+                "wednesday": "Mercredi",
+                "thursday": "Jeudi",
+                "friday": "Vendredi",
+                "saturday": "Samedi",
+                "sunday": "Dimanche"
+            }
+        },
+        "command_options": {
+            "options": {
+                "mow": "Tondre",
+                "returnToDock": "Retour à la station de charge",
+                "pause": "Pause"
             }
         }
     },

--- a/custom_components/indego/translations/fr.json
+++ b/custom_components/indego/translations/fr.json
@@ -295,6 +295,33 @@
                     "description": "Numéro de série de la tondeuse. Uniquement nécessaire si vous avez configuré plusieurs tondeuses."
                 }
             }
+        },
+        "set_calendar_slot": {
+            "name": "Activer/désactiver un créneau du calendrier",
+            "description": "Modifier un créneau du calendrier (changer les horaires, activer ou désactiver)",
+            "fields": {
+                "mower_serial": {
+                    "description": "Numéro de série de la tondeuse. Nécessaire uniquement si plusieurs tondeuses sont configurées."
+                },
+                "calendar_type": {
+                    "description": "Sélectionnez le calendrier ('calendar' pour le calendrier manuel ou 'predictive' pour les périodes désactivées en mode SmartMowing)."
+                },
+                "day": {
+                    "description": "Nom du jour de la semaine à configurer."
+                },
+                "slot": {
+                    "description": "Créneau horaire à modifier (1 ou 2)."
+                },
+                "enabled": {
+                    "description": "Activer ou désactiver le jour/créneau sélectionné."
+                },
+                "start": {
+                    "description": "Heure de début du créneau sélectionné. Requise uniquement lorsqu’un créneau doit être activé."
+                },
+                "end": {
+                    "description": "Heure de fin du créneau sélectionné. Requise uniquement lorsqu’un créneau doit être activé."
+                }
+            }
         }
     },
     "issues": {

--- a/custom_components/indego/translations/it.json
+++ b/custom_components/indego/translations/it.json
@@ -295,6 +295,33 @@
                     "description": "Numero di serie del rasaerba. Necessario solo quando hai configurato più rasaerba."
                 }
             }
+        },
+        "set_calendar_slot": {
+            "name": "Attiva/disattiva slot del calendario",
+            "description": "Modifica uno slot del calendario (cambia orari, attiva o disattiva)",
+            "fields": {
+                "mower_serial": {
+                    "description": "Numero di serie del rasaerba. Necessario solo se sono configurati più rasaerba."
+                },
+                "calendar_type": {
+                    "description": "Seleziona il calendario ('calendar' per il calendario manuale o 'predictive' per i periodi disattivati in modalità SmartMowing)."
+                },
+                "day": {
+                    "description": "Nome del giorno della settimana da configurare."
+                },
+                "slot": {
+                    "description": "Slot orario da modificare (1 o 2)."
+                },
+                "enabled": {
+                    "description": "Attiva o disattiva il giorno/slot selezionato."
+                },
+                "start": {
+                    "description": "Ora di inizio dello slot selezionato. Necessaria solo se lo slot deve essere attivato."
+                },
+                "end": {
+                    "description": "Ora di fine dello slot selezionato. Necessaria solo se lo slot deve essere attivato."
+                }
+            }
         }
     },
     "issues": {

--- a/custom_components/indego/translations/it.json
+++ b/custom_components/indego/translations/it.json
@@ -301,26 +301,59 @@
             "description": "Modifica uno slot del calendario (cambia orari, attiva o disattiva)",
             "fields": {
                 "mower_serial": {
+                    "name": "Numero di serie",
                     "description": "Numero di serie del rasaerba. Necessario solo se sono configurati più rasaerba."
                 },
                 "calendar_type": {
+                    "name": "Tipo di calendario",
                     "description": "Seleziona il calendario ('calendar' per il calendario manuale o 'predictive' per i periodi disattivati in modalità SmartMowing)."
                 },
                 "day": {
+                    "name": "Giorno",
                     "description": "Nome del giorno della settimana da configurare."
                 },
                 "slot": {
-                    "description": "Slot orario da modificare (1 o 2)."
+                    "name": "Fascia oraria",
+                    "description": "Quale fascia oraria deve essere modificata (1 o 2)."
                 },
                 "enabled": {
-                    "description": "Attiva o disattiva il giorno/slot selezionato."
+                    "name": "Attiva/disattiva",
+                    "description": "Attiva o disattiva il giorno/la fascia oraria selezionata."
                 },
                 "start": {
-                    "description": "Ora di inizio dello slot selezionato. Necessaria solo se lo slot deve essere attivato."
+                    "name": "Inizio",
+                    "description": "Ora di inizio della fascia selezionata. Necessaria solo se la fascia deve essere attivata. Vengono utilizzate solo ore e minuti."
                 },
                 "end": {
-                    "description": "Ora di fine dello slot selezionato. Necessaria solo se lo slot deve essere attivato."
+                    "name": "Fine",
+                    "description": "Ora di fine della fascia selezionata. Necessaria solo se la fascia deve essere attivata. Vengono utilizzate solo ore e minuti."
                 }
+            }
+        }
+    },
+    "selector": {
+        "calendar_type_options": {
+            "options": {
+                "calendar": "Calendario manuale",
+                "predictive": "Periodi bloccati SmartMowing"
+            }
+        },
+        "day_options": {
+            "options": {
+                "monday": "Lunedì",
+                "tuesday": "Martedì",
+                "wednesday": "Mercoledì",
+                "thursday": "Giovedì",
+                "friday": "Venerdì",
+                "saturday": "Sabato",
+                "sunday": "Domenica"
+            }
+        },
+        "command_options": {
+            "options": {
+                "mow": "Taglia l'erba",
+                "returnToDock": "Ritorna alla stazione di ricarica",
+                "pause": "Pausa"
             }
         }
     },

--- a/custom_components/indego/translations/nl.json
+++ b/custom_components/indego/translations/nl.json
@@ -295,6 +295,33 @@
                     "description": "Grasmaaier serienummer. Alleen nodig wanneer je meerdere grasmaaiers hebt geconfigureerd."
                 }
             }
+        },
+        "set_calendar_slot": {
+            "name": "Kalenderslot activeren/deactiveren",
+            "description": "Wijzig een kalenderslot (tijden wijzigen, activeren of deactiveren)",
+            "fields": {
+                "mower_serial": {
+                    "description": "Serienummer van de grasmaaier. Alleen nodig als er meerdere grasmaaiers zijn geconfigureerd."
+                },
+                "calendar_type": {
+                    "description": "Selecteer de kalender ('calendar' voor de handmatige kalender of 'predictive' voor gedeactiveerde tijden in SmartMowing-modus)."
+                },
+                "day": {
+                    "description": "Naam van de weekdag die moet worden geconfigureerd."
+                },
+                "slot": {
+                    "description": "Welk tijdslot moet worden gewijzigd (1 of 2)."
+                },
+                "enabled": {
+                    "description": "Activeer of deactiveer de geselecteerde dag/het geselecteerde slot."
+                },
+                "start": {
+                    "description": "Starttijd van het geselecteerde slot. Alleen nodig als een tijdslot moet worden geactiveerd."
+                },
+                "end": {
+                    "description": "Eindtijd van het geselecteerde slot. Alleen nodig als een tijdslot moet worden geactiveerd."
+                }
+            }
         }
     },
     "issues": {

--- a/custom_components/indego/translations/nl.json
+++ b/custom_components/indego/translations/nl.json
@@ -301,26 +301,59 @@
             "description": "Wijzig een kalenderslot (tijden wijzigen, activeren of deactiveren)",
             "fields": {
                 "mower_serial": {
+                    "name": "Serienummer",
                     "description": "Serienummer van de grasmaaier. Alleen nodig als er meerdere grasmaaiers zijn geconfigureerd."
                 },
                 "calendar_type": {
+                    "name": "Kalendertype",
                     "description": "Selecteer de kalender ('calendar' voor de handmatige kalender of 'predictive' voor gedeactiveerde tijden in SmartMowing-modus)."
                 },
                 "day": {
+                    "name": "Dag",
                     "description": "Naam van de weekdag die moet worden geconfigureerd."
                 },
                 "slot": {
+                    "name": "Tijdslot",
                     "description": "Welk tijdslot moet worden gewijzigd (1 of 2)."
                 },
                 "enabled": {
-                    "description": "Activeer of deactiveer de geselecteerde dag/het geselecteerde slot."
+                    "name": "Activeren/deactiveren",
+                    "description": "Activeer of deactiveer de geselecteerde dag/het geselecteerde tijdslot."
                 },
                 "start": {
-                    "description": "Starttijd van het geselecteerde slot. Alleen nodig als een tijdslot moet worden geactiveerd."
+                    "name": "Start",
+                    "description": "Starttijd van het geselecteerde tijdslot. Alleen nodig als het tijdslot geactiveerd moet worden. Alleen uren en minuten worden gebruikt."
                 },
                 "end": {
-                    "description": "Eindtijd van het geselecteerde slot. Alleen nodig als een tijdslot moet worden geactiveerd."
+                    "name": "Einde",
+                    "description": "Eindtijd van het geselecteerde tijdslot. Alleen nodig als het tijdslot geactiveerd moet worden. Alleen uren en minuten worden gebruikt."
                 }
+            }
+        }
+    },
+    "selector": {
+        "calendar_type_options": {
+            "options": {
+                "calendar": "Handmatige kalender",
+                "predictive": "SmartMowing-blokkeertijden"
+            }
+        },
+        "day_options": {
+            "options": {
+                "monday": "Maandag",
+                "tuesday": "Dinsdag",
+                "wednesday": "Woensdag",
+                "thursday": "Donderdag",
+                "friday": "Vrijdag",
+                "saturday": "Zaterdag",
+                "sunday": "Zondag"
+            }
+        },
+        "command_options": {
+            "options": {
+                "mow": "Maaien",
+                "returnToDock": "Terug naar het laadstation",
+                "pause": "Pauze"
             }
         }
     },

--- a/custom_components/indego/translations/no.json
+++ b/custom_components/indego/translations/no.json
@@ -295,6 +295,33 @@
                     "description": "Gressklipperens serienummer. Bare nødvendig hvis du har konfigurert flere gressklippere."
                 }
             }
+        },
+        "set_calendar_slot": {
+            "name": "Aktiver/deaktiver kalenderspor",
+            "description": "Endre et kalenderspor (endre tider, aktiver eller deaktiver)",
+            "fields": {
+                "mower_serial": {
+                    "description": "Serienummeret til gressklipperen. Kun nødvendig hvis flere gressklippere er konfigurert."
+                },
+                "calendar_type": {
+                    "description": "Velg kalender ('calendar' for manuell kalender eller 'predictive' for deaktiverte tidsrom i SmartMowing-modus)."
+                },
+                "day": {
+                    "description": "Navnet på ukedagen som skal konfigureres."
+                },
+                "slot": {
+                    "description": "Hvilket tidsrom som skal endres (1 eller 2)."
+                },
+                "enabled": {
+                    "description": "Aktiver eller deaktiver valgt dag/tidsrom."
+                },
+                "start": {
+                    "description": "Starttid for valgt tidsrom. Kun nødvendig hvis tidsrommet skal aktiveres."
+                },
+                "end": {
+                    "description": "Sluttid for valgt tidsrom. Kun nødvendig hvis tidsrommet skal aktiveres."
+                }
+            }
         }
     },
     "issues": {

--- a/custom_components/indego/translations/no.json
+++ b/custom_components/indego/translations/no.json
@@ -301,26 +301,59 @@
             "description": "Endre et kalenderspor (endre tider, aktiver eller deaktiver)",
             "fields": {
                 "mower_serial": {
+                    "name": "Serienummer",
                     "description": "Serienummeret til gressklipperen. Kun nødvendig hvis flere gressklippere er konfigurert."
                 },
                 "calendar_type": {
+                    "name": "Kalendertype",
                     "description": "Velg kalender ('calendar' for manuell kalender eller 'predictive' for deaktiverte tidsrom i SmartMowing-modus)."
                 },
                 "day": {
+                    "name": "Dag",
                     "description": "Navnet på ukedagen som skal konfigureres."
                 },
                 "slot": {
+                    "name": "Tidsrom",
                     "description": "Hvilket tidsrom som skal endres (1 eller 2)."
                 },
                 "enabled": {
+                    "name": "Aktiver/deaktiver",
                     "description": "Aktiver eller deaktiver valgt dag/tidsrom."
                 },
                 "start": {
-                    "description": "Starttid for valgt tidsrom. Kun nødvendig hvis tidsrommet skal aktiveres."
+                    "name": "Start",
+                    "description": "Starttid for valgt tidsrom. Kun nødvendig hvis tidsrommet skal aktiveres. Kun timer og minutter brukes."
                 },
                 "end": {
-                    "description": "Sluttid for valgt tidsrom. Kun nødvendig hvis tidsrommet skal aktiveres."
+                    "name": "Slutt",
+                    "description": "Sluttid for valgt tidsrom. Kun nødvendig hvis tidsrommet skal aktiveres. Kun timer og minutter brukes."
                 }
+            }
+        }
+    },
+    "selector": {
+        "calendar_type_options": {
+            "options": {
+                "calendar": "Manuell kalender",
+                "predictive": "SmartMowing-blokkerte tider"
+            }
+        },
+        "day_options": {
+            "options": {
+                "monday": "Mandag",
+                "tuesday": "Tirsdag",
+                "wednesday": "Onsdag",
+                "thursday": "Torsdag",
+                "friday": "Fredag",
+                "saturday": "Lørdag",
+                "sunday": "Søndag"
+            }
+        },
+        "command_options": {
+            "options": {
+                "mow": "Klipp gress",
+                "returnToDock": "Tilbake til ladestasjonen",
+                "pause": "Pause"
             }
         }
     },

--- a/custom_components/indego/translations/pl.json
+++ b/custom_components/indego/translations/pl.json
@@ -13,8 +13,8 @@
                     "expose_mower": "Wyświetl kosiarkę Indego jako encję kosiarki w Home Assistant",
                     "expose_vacuum": "Wyświetl kosiarkę Indego jako encję odkurzacza w Home Assistant"
                 },
-                “data_description”: {
-                    “user_agent”: “W przypadku błędów HTTP 4XX (zwłaszcza Reason: 403, message=»Forbidden«) pomocna może okazać się zmiana agenta użytkownika. Nie powinien on zawierać słów „Homeassistant” ani „HA”.”
+                "data_description": {
+                    "user_agent": "W przypadku błędów HTTP 4XX (zwłaszcza Reason: 403, message=»Forbidden«) pomocna może okazać się zmiana agenta użytkownika. Nie powinien on zawierać słów „Homeassistant” ani „HA”."
                 },
                 "description": "Ustawienia zaawansowane komponentu Bosch Indego."
             },
@@ -301,26 +301,59 @@
             "description": "Zmień przedział kalendarza (zmień godziny, aktywuj lub dezaktywuj)",
             "fields": {
                 "mower_serial": {
+                    "name": "Numer seryjny",
                     "description": "Numer seryjny kosiarki. Wymagany tylko wtedy, gdy skonfigurowano kilka kosiarek."
                 },
                 "calendar_type": {
+                    "name": "Typ kalendarza",
                     "description": "Wybierz kalendarz ('calendar' dla kalendarza ręcznego lub 'predictive' dla dezaktywowanych okresów w trybie SmartMowing)."
                 },
                 "day": {
+                    "name": "Dzień",
                     "description": "Nazwa dnia tygodnia, który ma zostać skonfigurowany."
                 },
                 "slot": {
+                    "name": "Przedział czasowy",
                     "description": "Który przedział czasowy ma zostać zmieniony (1 lub 2)."
                 },
                 "enabled": {
-                    "description": "Aktywuj lub dezaktywuj wybrany dzień/przedział."
+                    "name": "Aktywuj/dezaktywuj",
+                    "description": "Aktywuj lub dezaktywuj wybrany dzień/przedział czasowy."
                 },
                 "start": {
-                    "description": "Godzina rozpoczęcia wybranego przedziału. Wymagana tylko wtedy, gdy przedział czasowy ma zostać aktywowany."
+                    "name": "Start",
+                    "description": "Godzina rozpoczęcia wybranego przedziału. Wymagana tylko wtedy, gdy przedział ma zostać aktywowany. Używane są tylko godziny i minuty."
                 },
                 "end": {
-                    "description": "Godzina zakończenia wybranego przedziału. Wymagana tylko wtedy, gdy przedział czasowy ma zostać aktywowany."
+                    "name": "Koniec",
+                    "description": "Godzina zakończenia wybranego przedziału. Wymagana tylko wtedy, gdy przedział ma zostać aktywowany. Używane są tylko godziny i minuty."
                 }
+            }
+        }
+    },
+    "selector": {
+        "calendar_type_options": {
+            "options": {
+                "calendar": "Kalendarz ręczny",
+                "predictive": "Okresy blokady SmartMowing"
+            }
+        },
+        "day_options": {
+            "options": {
+                "monday": "Poniedziałek",
+                "tuesday": "Wtorek",
+                "wednesday": "Środa",
+                "thursday": "Czwartek",
+                "friday": "Piątek",
+                "saturday": "Sobota",
+                "sunday": "Niedziela"
+            }
+        },
+        "command_options": {
+            "options": {
+                "mow": "Koszenie",
+                "returnToDock": "Powrót do stacji dokującej",
+                "pause": "Pauza"
             }
         }
     },

--- a/custom_components/indego/translations/pl.json
+++ b/custom_components/indego/translations/pl.json
@@ -295,6 +295,33 @@
                     "description": "Numer seryjny kosiarki. Wymagany tylko gdy konfigurujesz wiele kosiarek."
                 }
             }
+        },
+        "set_calendar_slot": {
+            "name": "Aktywuj/dezaktywuj przedział kalendarza",
+            "description": "Zmień przedział kalendarza (zmień godziny, aktywuj lub dezaktywuj)",
+            "fields": {
+                "mower_serial": {
+                    "description": "Numer seryjny kosiarki. Wymagany tylko wtedy, gdy skonfigurowano kilka kosiarek."
+                },
+                "calendar_type": {
+                    "description": "Wybierz kalendarz ('calendar' dla kalendarza ręcznego lub 'predictive' dla dezaktywowanych okresów w trybie SmartMowing)."
+                },
+                "day": {
+                    "description": "Nazwa dnia tygodnia, który ma zostać skonfigurowany."
+                },
+                "slot": {
+                    "description": "Który przedział czasowy ma zostać zmieniony (1 lub 2)."
+                },
+                "enabled": {
+                    "description": "Aktywuj lub dezaktywuj wybrany dzień/przedział."
+                },
+                "start": {
+                    "description": "Godzina rozpoczęcia wybranego przedziału. Wymagana tylko wtedy, gdy przedział czasowy ma zostać aktywowany."
+                },
+                "end": {
+                    "description": "Godzina zakończenia wybranego przedziału. Wymagana tylko wtedy, gdy przedział czasowy ma zostać aktywowany."
+                }
+            }
         }
     },
     "issues": {

--- a/custom_components/indego/translations/sk.json
+++ b/custom_components/indego/translations/sk.json
@@ -301,26 +301,59 @@
             "description": "Upraviť časový slot kalendára (zmeniť časy, aktivovať alebo deaktivovať)",
             "fields": {
                 "mower_serial": {
+                    "name": "Sériové číslo",
                     "description": "Sériové číslo kosačky. Vyžaduje sa iba v prípade, že je nakonfigurovaných viac kosačiek."
                 },
                 "calendar_type": {
+                    "name": "Typ kalendára",
                     "description": "Vyberte kalendár ('calendar' pre manuálny kalendár alebo 'predictive' pre deaktivované časové obdobia v režime SmartMowing)."
                 },
                 "day": {
+                    "name": "Deň",
                     "description": "Názov dňa v týždni, ktorý sa má nakonfigurovať."
                 },
                 "slot": {
+                    "name": "Časový slot",
                     "description": "Ktorý časový slot sa má zmeniť (1 alebo 2)."
                 },
                 "enabled": {
+                    "name": "Aktivovať/deaktivovať",
                     "description": "Aktivovať alebo deaktivovať vybraný deň/časový slot."
                 },
                 "start": {
-                    "description": "Čas začiatku vybraného slotu. Vyžaduje sa iba v prípade, že sa má časový slot aktivovať."
+                    "name": "Začiatok",
+                    "description": "Čas začiatku vybraného slotu. Vyžaduje sa iba v prípade, že sa má slot aktivovať. Použijú sa iba hodiny a minúty."
                 },
                 "end": {
-                    "description": "Čas ukončenia vybraného slotu. Vyžaduje sa iba v prípade, že sa má časový slot aktivovať."
+                    "name": "Koniec",
+                    "description": "Čas ukončenia vybraného slotu. Vyžaduje sa iba v prípade, že sa má slot aktivovať. Použijú sa iba hodiny a minúty."
                 }
+            }
+        }
+    },
+    "selector": {
+        "calendar_type_options": {
+            "options": {
+                "calendar": "Manuálny kalendár",
+                "predictive": "Blokované časy SmartMowing"
+            }
+        },
+        "day_options": {
+            "options": {
+                "monday": "Pondelok",
+                "tuesday": "Utorok",
+                "wednesday": "Streda",
+                "thursday": "Štvrtok",
+                "friday": "Piatok",
+                "saturday": "Sobota",
+                "sunday": "Nedeľa"
+            }
+        },
+        "command_options": {
+            "options": {
+                "mow": "Kosiť",
+                "returnToDock": "Návrat do dokovacej stanice",
+                "pause": "Pauza"
             }
         }
     },

--- a/custom_components/indego/translations/sk.json
+++ b/custom_components/indego/translations/sk.json
@@ -295,6 +295,33 @@
                     "description": "Sériové číslo kosačky. Potrebné iba vtedy, keď máte nakonfigurovaných viacero kosačiek."
                 }
             }
+        },
+        "set_calendar_slot": {
+            "name": "Aktivovať/deaktivovať časový slot kalendára",
+            "description": "Upraviť časový slot kalendára (zmeniť časy, aktivovať alebo deaktivovať)",
+            "fields": {
+                "mower_serial": {
+                    "description": "Sériové číslo kosačky. Vyžaduje sa iba v prípade, že je nakonfigurovaných viac kosačiek."
+                },
+                "calendar_type": {
+                    "description": "Vyberte kalendár ('calendar' pre manuálny kalendár alebo 'predictive' pre deaktivované časové obdobia v režime SmartMowing)."
+                },
+                "day": {
+                    "description": "Názov dňa v týždni, ktorý sa má nakonfigurovať."
+                },
+                "slot": {
+                    "description": "Ktorý časový slot sa má zmeniť (1 alebo 2)."
+                },
+                "enabled": {
+                    "description": "Aktivovať alebo deaktivovať vybraný deň/časový slot."
+                },
+                "start": {
+                    "description": "Čas začiatku vybraného slotu. Vyžaduje sa iba v prípade, že sa má časový slot aktivovať."
+                },
+                "end": {
+                    "description": "Čas ukončenia vybraného slotu. Vyžaduje sa iba v prípade, že sa má časový slot aktivovať."
+                }
+            }
         }
     },
     "issues": {

--- a/custom_components/indego/translations/sv.json
+++ b/custom_components/indego/translations/sv.json
@@ -295,6 +295,33 @@
                     "description": "Gräsklippare serienummer. Krävs endast när du har flera gräsklippare konfigurerade."
                 }
             }
+        },
+        "set_calendar_slot": {
+            "name": "Aktivera/inaktivera kalenderintervall",
+            "description": "Ändra en kalenderplats (ändra tider, aktivera eller inaktivera)",
+            "fields": {
+                "mower_serial": {
+                    "description": "Gräsklipparens serienummer. Krävs endast om flera gräsklippare är konfigurerade."
+                },
+                "calendar_type": {
+                    "description": "Välj kalender ('calendar' för den manuella kalendern eller 'predictive' för inaktiverade tidsperioder i SmartMowing-läge)."
+                },
+                "day": {
+                    "description": "Namnet på veckodagen som ska konfigureras."
+                },
+                "slot": {
+                    "description": "Vilken tidsintervall som ska ändras (1 eller 2)."
+                },
+                "enabled": {
+                    "description": "Aktivera eller inaktivera vald dag/tidsplats."
+                },
+                "start": {
+                    "description": "Starttid för den valda tidsplatsen. Krävs endast om tidsplatsen ska aktiveras."
+                },
+                "end": {
+                    "description": "Sluttid för den valda tidsplatsen. Krävs endast om tidsplatsen ska aktiveras."
+                }
+            }
         }
     },
     "issues": {

--- a/custom_components/indego/translations/sv.json
+++ b/custom_components/indego/translations/sv.json
@@ -298,29 +298,62 @@
         },
         "set_calendar_slot": {
             "name": "Aktivera/inaktivera kalenderintervall",
-            "description": "Ändra en kalenderplats (ändra tider, aktivera eller inaktivera)",
+            "description": "Ändra ett kalenderintervall (ändra tider, aktivera eller inaktivera)",
             "fields": {
                 "mower_serial": {
+                    "name": "Serienummer",
                     "description": "Gräsklipparens serienummer. Krävs endast om flera gräsklippare är konfigurerade."
                 },
                 "calendar_type": {
+                    "name": "Kalendertyp",
                     "description": "Välj kalender ('calendar' för den manuella kalendern eller 'predictive' för inaktiverade tidsperioder i SmartMowing-läge)."
                 },
                 "day": {
+                    "name": "Dag",
                     "description": "Namnet på veckodagen som ska konfigureras."
                 },
                 "slot": {
-                    "description": "Vilken tidsintervall som ska ändras (1 eller 2)."
+                    "name": "Tidsintervall",
+                    "description": "Vilket tidsintervall som ska ändras (1 eller 2)."
                 },
                 "enabled": {
-                    "description": "Aktivera eller inaktivera vald dag/tidsplats."
+                    "name": "Aktivera/inaktivera",
+                    "description": "Aktivera eller inaktivera vald dag/tidsintervall."
                 },
                 "start": {
-                    "description": "Starttid för den valda tidsplatsen. Krävs endast om tidsplatsen ska aktiveras."
+                    "name": "Start",
+                    "description": "Starttid för valt tidsintervall. Krävs endast om tidsintervallet ska aktiveras. Endast timmar och minuter används."
                 },
                 "end": {
-                    "description": "Sluttid för den valda tidsplatsen. Krävs endast om tidsplatsen ska aktiveras."
+                    "name": "Slut",
+                    "description": "Sluttid för valt tidsintervall. Krävs endast om tidsintervallet ska aktiveras. Endast timmar och minuter används."
                 }
+            }
+        }
+    },
+    "selector": {
+        "calendar_type_options": {
+            "options": {
+                "calendar": "Manuell kalender",
+                "predictive": "SmartMowing-blockerade tider"
+            }
+        },
+        "day_options": {
+            "options": {
+                "monday": "Måndag",
+                "tuesday": "Tisdag",
+                "wednesday": "Onsdag",
+                "thursday": "Torsdag",
+                "friday": "Fredag",
+                "saturday": "Lördag",
+                "sunday": "Söndag"
+            }
+        },
+        "command_options": {
+            "options": {
+                "mow": "Klipp gräs",
+                "returnToDock": "Återvänd till laddstationen",
+                "pause": "Paus"
             }
         }
     },


### PR DESCRIPTION
This PR replaces #38. It includes all fixes and optimizations from there. 
Additionally this PR includes two new sensors which show the configured time slots of the manual calendar and also the predicted time slots from the SmartMowing calendar.
A new service was created called indego.set_calendar_slot which makes it possible to set the time slots from HA to the Bosch API.
All translation files were updated with the new service.