### PR TITLE
Fix for #41

### DIFF
--- a/custom_components/boschindego/const.py
+++ b/custom_components/boschindego/const.py
@@ -1,7 +1,7 @@
 """Constants for Indego integration."""
 from typing import Final
 
-DOMAIN: Final = "indego"
+DOMAIN: Final = "boschindego"
 
 OAUTH2_AUTHORIZE: Final = "https://prodindego.b2clogin.com/prodindego.onmicrosoft.com/b2c_1a_signup_signin/oauth2/v2.0/authorize"
 OAUTH2_TOKEN: Final = "https://prodindego.b2clogin.com/prodindego.onmicrosoft.com/b2c_1a_signup_signin/oauth2/v2.0/token"

--- a/custom_components/boschindego/manifest.json
+++ b/custom_components/boschindego/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/whylev/Indego/issues",
   "loggers": [
-    "custom_components.indego",
+    "custom_components.boschindego",
     "pyIndego"
   ],
   "requirements": [


### PR DESCRIPTION
Fix for issue #41 where custom_components.indego in manifest.json and DOMAIN: Final = "indego" in const.py caused an issue when loading the integration.
Changed to custom_components.boschindego in manifest.json and DOMAIN: Final = "boschindego" in const.py 