### PR TITLE
Enhancements for Calendar and SmartMowing

### DIFF
--- a/custom_components/boschindego/__init__.py
+++ b/custom_components/boschindego/__init__.py
@@ -548,8 +548,8 @@ def _calendar_slots_by_day(calendar) -> dict:
     ]
 
     for day_name in day_names:
-        result[f"{day_name}_slot_1"] = "not enabled"
-        result[f"{day_name}_slot_2"] = "not enabled"
+        result[f"{day_name}_slot_1"] = "not_enabled"
+        result[f"{day_name}_slot_2"] = "not_enabled"
 
     if calendar is None or not getattr(calendar, "days", None):
         return result
@@ -565,7 +565,7 @@ def _calendar_slots_by_day(calendar) -> dict:
             attr_name = f"{day_name}_slot_{index + 1}"
 
             if index >= len(slots):
-                result[attr_name] = "not configured"
+                result[attr_name] = "not_configured"
                 continue
 
             slot = slots[index]
@@ -573,7 +573,7 @@ def _calendar_slots_by_day(calendar) -> dict:
             if getattr(slot, "En", False):
                 result[attr_name] = _format_calendar_slot(slot)
             else:
-                result[attr_name] = "not enabled"
+                result[attr_name] = "not_enabled"
 
     return result
 
@@ -586,7 +586,7 @@ def _today_calendar_slots(slots_by_day: dict) -> list:
             slots_by_day.get(f"{today_name}_slot_1"),
             slots_by_day.get(f"{today_name}_slot_2"),
         ]
-        if slot not in (None, "not enabled", "not configured")
+        if slot not in (None, "not_enabled", "not_configured")
     ]
 
 def _today_calendar_day_name() -> str:
@@ -699,10 +699,10 @@ def _predictive_calendar_payload(earliest_start: str, latest_end: str) -> dict:
 
 def _predictive_calendar_window(calendar) -> dict:
     result = {
-        "earliest_start": "not enabled",
-        "latest_end": "not enabled",
-        "blocked_before": "not enabled",
-        "blocked_after": "not enabled",
+        "earliest_start": "not_enabled",
+        "latest_end": "not_enabled",
+        "blocked_before": "not_enabled",
+        "blocked_after": "not_enabled",
     }
 
     if calendar is None or not getattr(calendar, "days", None):
@@ -778,7 +778,7 @@ def _predictive_schedule_attributes(schedule) -> dict:
     }
 
     for day_name in day_names:
-        attrs[f"schedule_{day_name}"] = "not scheduled"
+        attrs[f"schedule_{day_name}"] = "not_scheduled"
         attrs[f"exclusion_{day_name}_user"] = "none"
         attrs[f"exclusion_{day_name}_weather"] = "none"
 
@@ -1312,7 +1312,7 @@ class IndegoHub:
         sensor = self.entities[ENTITY_PREDICTIVE_SCHEDULE]
 
         if not _is_smartmowing_active(self._indego_client.generic_data):
-            sensor.state = "manual calendar active"
+            sensor.state = "manual_calendar_active"
         else:
             sensor.state = attrs["next_mow_slot"]
 
@@ -1830,10 +1830,10 @@ class IndegoHub:
         sensor = self.entities[ENTITY_PREDICTIVE_CALENDAR_SLOTS]
 
         if not _is_smartmowing_active(self._indego_client.generic_data):
-            sensor.state = "manual calendar active"
+            sensor.state = "manual_calendar_active"
         elif (
-            window["earliest_start"] != "not enabled"
-            and window["latest_end"] != "not enabled"
+            window["earliest_start"] != "not_enabled"
+            and window["latest_end"] != "not_enabled"
         ):
             sensor.state = f"{window['earliest_start']}-{window['latest_end']}"
         else:
@@ -1866,7 +1866,7 @@ class IndegoHub:
         sensor = self.entities[ENTITY_CALENDAR_SLOTS]
 
         if _is_smartmowing_active(self._indego_client.generic_data):
-            sensor.state = "smartmowing active"
+            sensor.state = "smartmowing_active"
         else:
             sensor.state = ", ".join(today_slots) if today_slots else "off"
 

--- a/custom_components/boschindego/__init__.py
+++ b/custom_components/boschindego/__init__.py
@@ -1866,7 +1866,7 @@ class IndegoHub:
         sensor = self.entities[ENTITY_CALENDAR_SLOTS]
 
         if _is_smartmowing_active(self._indego_client.generic_data):
-            sensor.state = "SmartMowing active"
+            sensor.state = "smartmowing active"
         else:
             sensor.state = ", ".join(today_slots) if today_slots else "off"
 

--- a/custom_components/boschindego/__init__.py
+++ b/custom_components/boschindego/__init__.py
@@ -1312,7 +1312,7 @@ class IndegoHub:
         sensor = self.entities[ENTITY_PREDICTIVE_SCHEDULE]
 
         if not _is_smartmowing_active(self._indego_client.generic_data):
-            sensor.state = "Manual calendar active"
+            sensor.state = "manual calendar active"
         else:
             sensor.state = attrs["next_mow_slot"]
 
@@ -1830,7 +1830,7 @@ class IndegoHub:
         sensor = self.entities[ENTITY_PREDICTIVE_CALENDAR_SLOTS]
 
         if not _is_smartmowing_active(self._indego_client.generic_data):
-            sensor.state = "Manual calendar active"
+            sensor.state = "manual calendar active"
         elif (
             window["earliest_start"] != "not enabled"
             and window["latest_end"] != "not enabled"

--- a/custom_components/boschindego/__init__.py
+++ b/custom_components/boschindego/__init__.py
@@ -69,7 +69,7 @@ SERVICE_SCHEMA_COMMAND = vol.Schema({
 
 SERVICE_SCHEMA_SMARTMOWING = vol.Schema({
     vol.Optional(CONF_MOWER_SERIAL): cv.string,
-    vol.Required(CONF_SMARTMOWING): cv.string
+    vol.Required(CONF_SMARTMOWING): cv.boolean
 })
 
 SERVICE_SCHEMA_DELETE_ALERT = vol.Schema({
@@ -96,15 +96,23 @@ SERVICE_SCHEMA_DOWNLOAD_MAP = vol.Schema({
 
 SERVICE_SCHEMA_SET_CALENDAR_SLOT = vol.Schema({
     vol.Optional(CONF_MOWER_SERIAL): cv.string,
-    vol.Optional(CONF_CALENDAR_TYPE, default="calendar"): vol.In(["calendar", "predictive"]),
-    vol.Required(CONF_DAY): vol.In([
-        "monday", "tuesday", "wednesday", "thursday",
-        "friday", "saturday", "sunday",
-    ]),
+    vol.Required(CONF_DAYS): vol.All(
+        cv.ensure_list,
+        [vol.In([
+            "monday", "tuesday", "wednesday", "thursday",
+            "friday", "saturday", "sunday",
+        ])],
+    ),
     vol.Required(CONF_SLOT): vol.In([1, 2]),
     vol.Optional(CONF_ENABLED, default=True): cv.boolean,
     vol.Optional(CONF_START): cv.string,
     vol.Optional(CONF_END): cv.string,
+})
+
+SERVICE_SCHEMA_SET_PREDICTIVE_MOWING_WINDOW = vol.Schema({
+    vol.Optional(CONF_MOWER_SERIAL): cv.string,
+    vol.Required(CONF_EARLIEST_START): cv.string,
+    vol.Required(CONF_LATEST_END): cv.string,
 })
 
 
@@ -439,22 +447,11 @@ ENTITY_DEFINITIONS = {
         CONF_ATTR: [
             "last_updated",
             "smartmowing_enabled",
-            "today_slot_1",
-            "today_slot_2",
-            "monday_slot_1",
-            "monday_slot_2",
-            "tuesday_slot_1",
-            "tuesday_slot_2",
-            "wednesday_slot_1",
-            "wednesday_slot_2",
-            "thursday_slot_1",
-            "thursday_slot_2",
-            "friday_slot_1",
-            "friday_slot_2",
-            "saturday_slot_1",
-            "saturday_slot_2",
-            "sunday_slot_1",
-            "sunday_slot_2",
+            "mowing_mode",
+            "earliest_start",
+            "latest_end",
+            "blocked_before",
+            "blocked_after",
         ],
         CONF_TRANSLATION_KEY: "predictive_calendar_slots",
     },
@@ -483,6 +480,40 @@ ENTITY_DEFINITIONS = {
             "sunday_slot_2",
         ],
         CONF_TRANSLATION_KEY: "calendar_slots",
+    },
+    ENTITY_PREDICTIVE_SCHEDULE: {
+        CONF_TYPE: SENSOR_TYPE,
+        CONF_ICON: "mdi:calendar-search",
+        CONF_DEVICE_CLASS: None,
+        CONF_UNIT_OF_MEASUREMENT: None,
+        CONF_ATTR: [
+            "last_updated",
+            "next_mow_slot",
+            "next_mow_day",
+            "next_mow_time",
+            "schedule_monday",
+            "schedule_tuesday",
+            "schedule_wednesday",
+            "schedule_thursday",
+            "schedule_friday",
+            "schedule_saturday",
+            "schedule_sunday",
+            "exclusion_monday_user",
+            "exclusion_monday_weather",
+            "exclusion_tuesday_user",
+            "exclusion_tuesday_weather",
+            "exclusion_wednesday_user",
+            "exclusion_wednesday_weather",
+            "exclusion_thursday_user",
+            "exclusion_thursday_weather",
+            "exclusion_friday_user",
+            "exclusion_friday_weather",
+            "exclusion_saturday_user",
+            "exclusion_saturday_weather",
+            "exclusion_sunday_user",
+            "exclusion_sunday_weather",
+        ],
+        CONF_TRANSLATION_KEY: "predictive_schedule",
     },
 }
 
@@ -629,6 +660,66 @@ def _calendar_to_payload(calendar, selected_cal: int = 1) -> dict:
         ],
     }
 
+def _predictive_calendar_payload(earliest_start: str, latest_end: str) -> dict:
+    start_hour, start_minute = _parse_slot_time(earliest_start)
+    end_hour, end_minute = _parse_slot_time(latest_end)
+
+    days = []
+
+    for day_index in range(7):
+        days.append({
+            "day": day_index,
+            "slots": [
+                {
+                    "En": True,
+                    "StHr": 0,
+                    "StMin": 0,
+                    "EnHr": start_hour,
+                    "EnMin": start_minute,
+                },
+                {
+                    "En": True,
+                    "StHr": end_hour,
+                    "StMin": end_minute,
+                    "EnHr": 23,
+                    "EnMin": 59,
+                },
+            ],
+        })
+
+    return {
+        "sel_cal": 1,
+        "cals": [
+            {
+                "cal": 1,
+                "days": days,
+            }
+        ],
+    }
+
+def _predictive_calendar_window(calendar) -> dict:
+    result = {
+        "earliest_start": "not enabled",
+        "latest_end": "not enabled",
+        "blocked_before": "not enabled",
+        "blocked_after": "not enabled",
+    }
+
+    if calendar is None or not getattr(calendar, "days", None):
+        return result
+
+    first_day = calendar.days[0]
+    slots = getattr(first_day, "slots", [])
+
+    if len(slots) > 0 and getattr(slots[0], "En", False):
+        result["blocked_before"] = _format_calendar_slot(slots[0])
+        result["earliest_start"] = f"{slots[0].EnHr:02d}:{slots[0].EnMin:02d}"
+
+    if len(slots) > 1 and getattr(slots[1], "En", False):
+        result["blocked_after"] = _format_calendar_slot(slots[1])
+        result["latest_end"] = f"{slots[1].StHr:02d}:{slots[1].StMin:02d}"
+
+    return result
 
 def _set_payload_slot(payload: dict, day_name: str, slot_number: int, enabled: bool, start: str | None, end: str | None) -> dict:
     day_index = DAY_NAME_TO_INDEX[day_name]
@@ -661,6 +752,94 @@ def _set_payload_slot(payload: dict, day_name: str, slot_number: int, enabled: b
     })
 
     return payload
+
+def _schedule_slot_to_text(slot) -> str:
+    return (
+        f"{slot.StHr:02d}:{slot.StMin:02d}-"
+        f"{slot.EnHr:02d}:{slot.EnMin:02d}"
+    )
+
+
+def _predictive_schedule_attributes(schedule) -> dict:
+    day_names = [
+        "monday",
+        "tuesday",
+        "wednesday",
+        "thursday",
+        "friday",
+        "saturday",
+        "sunday",
+    ]
+
+    attrs = {
+        "next_mow_slot": "none",
+        "next_mow_day": "none",
+        "next_mow_time": "none",
+    }
+
+    for day_name in day_names:
+        attrs[f"schedule_{day_name}"] = "not scheduled"
+        attrs[f"exclusion_{day_name}_user"] = "none"
+        attrs[f"exclusion_{day_name}_weather"] = "none"
+
+    if schedule is None:
+        return attrs
+
+    schedule_days = getattr(schedule, "schedule_days", None) or []
+    exclusion_days = getattr(schedule, "exclusion_days", None) or []
+
+    for day in schedule_days:
+        day_name = getattr(day, "day_name", None)
+        if day_name not in day_names:
+            continue
+
+        slots = getattr(day, "slots", []) or []
+        slot_texts = [
+            _schedule_slot_to_text(slot)
+            for slot in slots
+            if getattr(slot, "En", True)
+        ]
+
+        if slot_texts:
+            attrs[f"schedule_{day_name}"] = ", ".join(slot_texts)
+
+            if attrs["next_mow_slot"] == "none":
+                attrs["next_mow_slot"] = f"{day_name} {slot_texts[0]}"
+                attrs["next_mow_day"] = day_name
+                attrs["next_mow_time"] = slot_texts[0]
+
+    for day in exclusion_days:
+        day_name = getattr(day, "day_name", None)
+        if day_name not in day_names:
+            continue
+
+        user_slots = []
+        weather_slots = []
+
+        for slot in getattr(day, "slots", []) or []:
+            text = _schedule_slot_to_text(slot)
+            attr = getattr(slot, "Attr", None)
+
+            if attr == "C":
+                user_slots.append(text)
+            else:
+                weather_slots.append(text)
+
+        if user_slots:
+            attrs[f"exclusion_{day_name}_user"] = ", ".join(user_slots)
+
+        if weather_slots:
+            attrs[f"exclusion_{day_name}_weather"] = ", ".join(weather_slots)
+
+    return attrs
+
+def _is_smartmowing_active(generic_data) -> bool:
+    mowing_mode = getattr(
+        generic_data,
+        "mowing_mode_description",
+        None,
+    )
+    return str(mowing_mode).lower() == "smartmowing"
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Load a config entry."""
@@ -751,10 +930,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         """Handle the smartmowing service call."""
         instance = find_instance_for_mower_service_call(call)
         enable = call.data.get(CONF_SMARTMOWING, DEFAULT_NAME_COMMANDS)
-        _LOGGER.info("Setting smart mowing mode to: %s (Mower: %s)", enable, instance._serial)
+        enable_bool = enable is True
 
-        await instance._indego_client.put_mow_mode(enable)
+        _LOGGER.info("Setting smart mowing mode to: %s (Mower: %s)", enable_bool, instance._serial)
+
+        await instance._indego_client.put_mow_mode(enable_bool)
+
+        if ENTITY_SMARTMOWING_SWITCH in instance.entities:
+            instance.entities[ENTITY_SMARTMOWING_SWITCH].is_on = enable_bool
+
+        await asyncio.sleep(3)
+
         await instance._update_generic_data()
+        await instance._update_predictive_calendar()
 
     async def async_delete_alert(call):
         """Handle the service call."""
@@ -834,20 +1022,27 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         """Handle set_calendar_slot service call."""
         instance = find_instance_for_mower_service_call(call)
 
-        calendar_type = call.data[CONF_CALENDAR_TYPE]
-        day = call.data[CONF_DAY]
+        days = call.data[CONF_DAYS]
         slot = call.data[CONF_SLOT]
         enabled = call.data[CONF_ENABLED]
         start = call.data.get(CONF_START)
         end = call.data.get(CONF_END)
 
         await instance.async_set_calendar_slot(
-            calendar_type=calendar_type,
-            day=day,
+            days=days,
             slot=slot,
             enabled=enabled,
             start=start,
             end=end,
+        )
+
+    async def async_set_predictive_mowing_window(call):
+        """Handle set_predictive_mowing_window service call."""
+        instance = find_instance_for_mower_service_call(call)
+
+        await instance.async_set_predictive_mowing_window(
+            earliest_start=call.data[CONF_EARLIEST_START],
+            latest_end=call.data[CONF_LATEST_END],
         )
 
     # In HASS we can have multiple Indego component instances as long as the mower serial is unique.
@@ -903,6 +1098,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             SERVICE_NAME_SET_CALENDAR_SLOT,
             async_set_calendar_slot,
             schema=SERVICE_SCHEMA_SET_CALENDAR_SLOT,
+        )
+
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_NAME_SET_PREDICTIVE_MOWING_WINDOW,
+            async_set_predictive_mowing_window,
+            schema=SERVICE_SCHEMA_SET_PREDICTIVE_MOWING_WINDOW,
         )
 
         hass.data[DOMAIN][CONF_SERVICES_REGISTERED] = entry.entry_id
@@ -1023,8 +1225,7 @@ class IndegoHub:
 
     async def async_set_calendar_slot(
         self,
-        calendar_type: str,
-        day: str,
+        days: list[str],
         slot: int,
         enabled: bool,
         start: str | None = None,
@@ -1032,9 +1233,8 @@ class IndegoHub:
     ):
         """Set one calendar slot."""
         _LOGGER.info(
-            "Setting %s calendar slot: day=%s slot=%s enabled=%s start=%s end=%s mower=%s",
-            calendar_type,
-            day,
+            "Setting calendar slot: days=%s slot=%s enabled=%s start=%s end=%s mower=%s",
+            days,
             slot,
             enabled,
             start,
@@ -1053,22 +1253,12 @@ class IndegoHub:
                 _LOGGER.error("Invalid time format for slot: %s", e)
                 raise HomeAssistantError(f"Invalid time format: {e}") from e
 
-        if calendar_type == "predictive":
-            await self._indego_client.update_predictive_calendar()
-            calendar = getattr(self._indego_client, "predictive_calendar", None)
-
-            payload = _calendar_to_payload(calendar, selected_cal=1)
-            payload = _set_payload_slot(payload, day, slot, enabled, start, end)
-
-            await self._indego_client.put_predictive_cal(payload)
-            await self._update_predictive_calendar()
-            return
-
         await self._indego_client.update_calendar()
         calendar = getattr(self._indego_client, "calendar", None)
 
         payload = _calendar_to_payload(calendar, selected_cal=1)
-        payload = _set_payload_slot(payload, day, slot, enabled, start, end)
+        for day in days:
+            payload = _set_payload_slot(payload, day, slot, enabled, start, end)
 
         # Experimental: pyIndego documents GET /calendar, but not PUT /calendar.
         result = await self._indego_client.put(
@@ -1079,6 +1269,59 @@ class IndegoHub:
         _LOGGER.warning("SET CALENDAR SLOT RESULT = %r", result)
 
         await self._update_calendar()
+
+    async def async_set_predictive_mowing_window(
+        self,
+        earliest_start: str,
+        latest_end: str,
+    ):
+        """Set SmartMowing allowed mowing window."""
+        _LOGGER.info(
+            "Setting predictive mowing window: earliest_start=%s latest_end=%s mower=%s",
+            earliest_start,
+            latest_end,
+            self._serial,
+        )
+
+        payload = _predictive_calendar_payload(earliest_start, latest_end)
+
+        result = await self._indego_client.put_predictive_cal(payload)
+
+        _LOGGER.debug("Set predictive mowing window result: %r", result)
+
+        await self._update_predictive_calendar()
+
+    async def _update_predictive_schedule(self):
+        """Update SmartMowing predictive schedule."""
+        _LOGGER.debug("Fetching predictive schedule from Bosch API")
+
+        await self._indego_client.update_predictive_schedule()
+
+        schedule = getattr(self._indego_client, "predictive_schedule", None)
+
+#        _LOGGER.warning(
+#            "PREDICTIVE SCHEDULE = %r",
+#            schedule
+#        )
+
+        if ENTITY_PREDICTIVE_SCHEDULE not in self.entities:
+            return
+
+        attrs = _predictive_schedule_attributes(schedule)
+
+        sensor = self.entities[ENTITY_PREDICTIVE_SCHEDULE]
+
+        if not _is_smartmowing_active(self._indego_client.generic_data):
+            sensor.state = "Manual calendar active"
+        else:
+            sensor.state = attrs["next_mow_slot"]
+
+        sensor.set_attributes(
+            {
+                "last_updated": last_updated_now(),
+                **attrs,
+            }
+        )
 
     async def async_send_command_to_client(self, command: str):
         """Send a mower command to the Indego client."""
@@ -1359,6 +1602,7 @@ class IndegoHub:
                 self._update_last_completed_mow(),
                 self._update_next_mow(),
                 self._update_predictive_calendar(),
+                self._update_predictive_schedule(),
                 self._update_calendar(),
             ],
             return_exceptions=True,
@@ -1563,7 +1807,7 @@ class IndegoHub:
             _LOGGER.error("Unexpected error while updating operating data: %s", str(exc))
 
     async def _update_predictive_calendar(self):
-        """Update predictive calendar data / smart mowing blocked slots."""
+        """Update predictive calendar data / SmartMowing allowed mowing window."""
         _LOGGER.debug("Fetching predictive calendar from Bosch API")
 
         await self._indego_client.update_predictive_calendar()
@@ -1581,24 +1825,26 @@ class IndegoHub:
 
         smartmowing_enabled = str(mowing_mode).lower() == "smartmowing"
 
-        slots_by_day = _calendar_slots_by_day(calendar)
-        today_name = _today_calendar_day_name()
-        today_slots = _today_calendar_slots(slots_by_day)
+        window = _predictive_calendar_window(calendar)
 
         sensor = self.entities[ENTITY_PREDICTIVE_CALENDAR_SLOTS]
 
-        if not smartmowing_enabled:
-            sensor.state = "off"
+        if not _is_smartmowing_active(self._indego_client.generic_data):
+            sensor.state = "Manual calendar active"
+        elif (
+            window["earliest_start"] != "not enabled"
+            and window["latest_end"] != "not enabled"
+        ):
+            sensor.state = f"{window['earliest_start']}-{window['latest_end']}"
         else:
-            sensor.state = ", ".join(today_slots) if today_slots else "off"
+            sensor.state = "off"
 
         sensor.set_attributes(
             {
                 "last_updated": last_updated_now(),
                 "smartmowing_enabled": smartmowing_enabled,
-                "today_slot_1": slots_by_day.get(f"{today_name}_slot_1"),
-                "today_slot_2": slots_by_day.get(f"{today_name}_slot_2"),
-                **slots_by_day,
+                "mowing_mode": mowing_mode,
+                **window,
             }
         )
 
@@ -1618,7 +1864,11 @@ class IndegoHub:
         today_slots = _today_calendar_slots(slots_by_day)
 
         sensor = self.entities[ENTITY_CALENDAR_SLOTS]
-        sensor.state = ", ".join(today_slots) if today_slots else "off"
+
+        if _is_smartmowing_active(self._indego_client.generic_data):
+            sensor.state = "SmartMowing active"
+        else:
+            sensor.state = ", ".join(today_slots) if today_slots else "off"
 
         sensor.set_attributes(
             {
@@ -1996,22 +2246,48 @@ class IndegoHub:
 
         try:
             if self._indego_client.generic_data:
+                mowing_mode = getattr(
+                    self._indego_client.generic_data,
+                    "mowing_mode_description",
+                    STATE_UNKNOWN,
+                )
+
                 if ENTITY_MOWING_MODE in self.entities:
-                    mowing_mode = getattr(
-                        self._indego_client.generic_data,
-                        'mowing_mode_description',
-                        STATE_UNKNOWN
-                    )
                     self.entities[ENTITY_MOWING_MODE].state = mowing_mode
                     _LOGGER.debug("Mowing mode: %s", mowing_mode)
+
+                if ENTITY_SMARTMOWING_SWITCH in self.entities:
+                    self.entities[ENTITY_SMARTMOWING_SWITCH].is_on = (
+                        str(mowing_mode).lower() == "smartmowing"
+                    )
+
             else:
                 _LOGGER.debug("Generic data is empty from API")
+
                 if ENTITY_MOWING_MODE in self.entities:
                     self.entities[ENTITY_MOWING_MODE].state = STATE_UNKNOWN
+
+                if ENTITY_SMARTMOWING_SWITCH in self.entities:
+                    self.entities[ENTITY_SMARTMOWING_SWITCH].is_on = False
+
         except Exception as exc:
             _LOGGER.error("Error processing generic data: %s", str(exc))
+
             if ENTITY_MOWING_MODE in self.entities:
                 self.entities[ENTITY_MOWING_MODE].state = STATE_UNKNOWN
+
+            if ENTITY_SMARTMOWING_SWITCH in self.entities:
+                self.entities[ENTITY_SMARTMOWING_SWITCH].is_on = False
+
+        try:
+            if ENTITY_PREDICTIVE_CALENDAR_SLOTS in self.entities:
+                await self._update_predictive_calendar()
+        except Exception as exc:
+            _LOGGER.debug(
+                "Could not refresh predictive calendar after generic data update: %s",
+                exc,
+            )
+
 
         return self._indego_client.generic_data
 

--- a/custom_components/boschindego/const.py
+++ b/custom_components/boschindego/const.py
@@ -29,12 +29,13 @@ CONF_POLLING: Final = "polling"
 CONF_ENABLED_BY_DEFAULT: Final = "enabled_by_default"
 CONF_ENTITY_CATEGORY: Final = "entity_category"
 
-CONF_CALENDAR_TYPE: Final = "calendar_type"
-CONF_DAY: Final = "day"
+CONF_DAYS: Final = "days"
 CONF_SLOT: Final = "slot"
 CONF_ENABLED: Final = "enabled"
 CONF_START: Final = "start"
 CONF_END: Final = "end"
+CONF_EARLIEST_START: Final = "earliest_start"
+CONF_LATEST_END: Final = "latest_end"
 
 CONF_SERVICE: Final = "service"
 CONF_SERVICE_DATA: Final = "service_data"
@@ -114,10 +115,12 @@ SERVICE_NAME_RESET_SMART_MOWING: Final = "reset_smart_mowing"
 
 # Calendar
 ENTITY_PREDICTIVE_CALENDAR_SLOTS: Final = "predictive_calendar_slots"
+ENTITY_PREDICTIVE_SCHEDULE: Final = "predictive_schedule"
 ENTITY_CALENDAR_SLOTS: Final = "calendar_slots"
 
 # Calendar services
 SERVICE_NAME_SET_CALENDAR_SLOT: Final = "set_calendar_slot"
+SERVICE_NAME_SET_PREDICTIVE_MOWING_WINDOW: Final = "set_predictive_mowing_window"
 
 
 DELETE_ALERTS_BATCH_DELAY_SECONDS: Final = 10

--- a/custom_components/boschindego/manifest.json
+++ b/custom_components/boschindego/manifest.json
@@ -19,5 +19,5 @@
   "requirements": [
     "pyIndego==3.2.2"
   ],
-  "version": "1.6.3"
+  "version": "1.6.5"
 }

--- a/custom_components/boschindego/services.yaml
+++ b/custom_components/boschindego/services.yaml
@@ -110,25 +110,14 @@ set_calendar_slot:
       required: false
       selector:
         text: {}
-    calendar_type:
-      name: Calendar type
-      description: Type of calendar to use. Use "calendar for manual calendar or "predictive" for the forbidden time slots in SmartMowing mode.
-      example: "calendar"
-      required: false
-      default: "calendar"
-      selector:
-        select:
-          translation_key: calendar_type_options
-          options:
-            - "calendar"
-            - "predictive"
-    day:
-      name: Day
+    days:
+      name: Days
       description: Which day to configure.
       example: "monday"
       required: true
       selector:
         select:
+          multiple: true
           translation_key: day_options
           options:
             - "monday"
@@ -168,5 +157,32 @@ set_calendar_slot:
       description: Set End Time of the selected slot and day. Only needed if you want to enable a slot. Only hour and minute will be used.
       example: '"20:00"'
       required: false
+      selector:
+        time: {}
+
+set_predictive_mowing_window:
+  description: Set the allowed mowing window for SmartMowing.
+  fields:
+    mower_serial:
+      name: Serial number
+      description: Serial number of the mower. Only required if multiple mowers are configured.
+      example: "0123456789"
+      required: false
+      selector:
+        text: {}
+
+    earliest_start:
+      name: Earliest start
+      description: Earliest time SmartMowing is allowed to mow. Only hours and minutes are used.
+      example: "08:00"
+      required: true
+      selector:
+        time: {}
+
+    latest_end:
+      name: Latest end
+      description: Latest time SmartMowing is allowed to mow. Only hours and minutes are used.
+      example: "20:00"
+      required: true
       selector:
         time: {}

--- a/custom_components/boschindego/switch.py
+++ b/custom_components/boschindego/switch.py
@@ -84,15 +84,18 @@ class IndegoSwitch(IndegoEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return true if switch is on."""
-        # Check if SmartMowing is enabled by parsing the mowing mode description
         try:
             mowing_mode = getattr(
-                self._indego_hub._indego_client.state, "mowing_mode_description", None
+                self._indego_hub._indego_client.generic_data,
+                "mowing_mode_description",
+                None,
             )
-            if mowing_mode:
-                # Check if mowing mode contains "Smart" (SmartMowing indicator)
-                self._is_on = "Smart" in str(mowing_mode)
+
+            if mowing_mode is not None:
+                self._is_on = str(mowing_mode).lower() == "smartmowing"
+
             return self._is_on
+
         except (AttributeError, TypeError):
             return self._is_on
 

--- a/custom_components/boschindego/translations/da.json
+++ b/custom_components/boschindego/translations/da.json
@@ -198,7 +198,7 @@
             },
             "calendar_slots": {
                 "state": {
-                    "smartmowing active": "SmartMowing aktiv",
+                    "smartmowing_active": "SmartMowing aktiv",
                     "off": "Fra"
                 },
                 "name": "Planlagte klippetider",
@@ -206,113 +206,113 @@
                     "today_slot_1": {
                         "name": "I dag slot 1",
                         "state": {
-                            "not enabled": "Ikke aktiveret",
-                            "not configured": "Ikke konfigureret"
+                            "not_enabled": "Ikke aktiveret",
+                            "not_configured": "Ikke konfigureret"
                         }
                     },
                     "today_slot_2": {
                         "name": "I dag slot 2",
                         "state": {
-                            "not enabled": "Ikke aktiveret",
-                            "not configured": "Ikke konfigureret"
+                            "not_enabled": "Ikke aktiveret",
+                            "not_configured": "Ikke konfigureret"
                         }
                     },
                     "monday_slot_1": {
                         "name": "Mandag Slot 1",
                         "state": {
-                            "not enabled": "Ikke aktiveret",
-                            "not configured": "Ikke konfigureret"
+                            "not_enabled": "Ikke aktiveret",
+                            "not_configured": "Ikke konfigureret"
                         }
                     },
                     "monday_slot_2": {
                         "name": "Mandag Slot 2",
                         "state": {
-                            "not enabled": "Ikke aktiveret",
-                            "not configured": "Ikke konfigureret"
+                            "not_enabled": "Ikke aktiveret",
+                            "not_configured": "Ikke konfigureret"
                         }
                     },
                     "tuesday_slot_1": {
                         "name": "Tirsdag Slot 1",
                         "state": {
-                            "not enabled": "Ikke aktiveret",
-                            "not configured": "Ikke konfigureret"
+                            "not_enabled": "Ikke aktiveret",
+                            "not_configured": "Ikke konfigureret"
                         }
                     },
                     "tuesday_slot_2": {
                         "name": "Tirsdag Slot 2",
                         "state": {
-                            "not enabled": "Ikke aktiveret",
-                            "not configured": "Ikke konfigureret"
+                            "not_enabled": "Ikke aktiveret",
+                            "not_configured": "Ikke konfigureret"
                         }
                     },
                     "wednesday_slot_1": {
                         "name": "Onsdag Slot 1",
                         "state": {
-                            "not enabled": "Ikke aktiveret",
-                            "not configured": "Ikke konfigureret"
+                            "not_enabled": "Ikke aktiveret",
+                            "not_configured": "Ikke konfigureret"
                         }
                     },
                     "wednesday_slot_2": {
                         "name": "Onsdag Slot 2",
                         "state": {
-                            "not enabled": "Ikke aktiveret",
-                            "not configured": "Ikke konfigureret"
+                            "not_enabled": "Ikke aktiveret",
+                            "not_configured": "Ikke konfigureret"
                         }
                     },
                     "thursday_slot_1": {
                         "name": "Torsdag Slot 1",
                         "state": {
-                            "not enabled": "Ikke aktiveret",
-                            "not configured": "Ikke konfigureret"
+                            "not_enabled": "Ikke aktiveret",
+                            "not_configured": "Ikke konfigureret"
                         }
                     },
                     "thursday_slot_2": {
                         "name": "Torsdag Slot 2",
                         "state": {
-                            "not enabled": "Ikke aktiveret",
-                            "not configured": "Ikke konfigureret"
+                            "not_enabled": "Ikke aktiveret",
+                            "not_configured": "Ikke konfigureret"
                         }
                     },
                     "friday_slot_1": {
                         "name": "Fredag Slot 1",
                         "state": {
-                            "not enabled": "Ikke aktiveret",
-                            "not configured": "Ikke konfigureret"
+                            "not_enabled": "Ikke aktiveret",
+                            "not_configured": "Ikke konfigureret"
                         }
                     },
                     "friday_slot_2": {
                         "name": "Fredag Slot 2",
                         "state": {
-                            "not enabled": "Ikke aktiveret",
-                            "not configured": "Ikke konfigureret"
+                            "not_enabled": "Ikke aktiveret",
+                            "not_configured": "Ikke konfigureret"
                         }
                     },
                     "saturday_slot_1": {
                         "name": "Lørdag Slot 1",
                         "state": {
-                            "not enabled": "Ikke aktiveret",
-                            "not configured": "Ikke konfigureret"
+                            "not_enabled": "Ikke aktiveret",
+                            "not_configured": "Ikke konfigureret"
                         }
                     },
                     "saturday_slot_2": {
                         "name": "Lørdag Slot 2",
                         "state": {
-                            "not enabled": "Ikke aktiveret",
-                            "not configured": "Ikke konfigureret"
+                            "not_enabled": "Ikke aktiveret",
+                            "not_configured": "Ikke konfigureret"
                         }
                     },
                     "sunday_slot_1": {
                         "name": "Søndag Slot 1",
                         "state": {
-                            "not enabled": "Ikke aktiveret",
-                            "not configured": "Ikke konfigureret"
+                            "not_enabled": "Ikke aktiveret",
+                            "not_configured": "Ikke konfigureret"
                         }
                     },
                     "sunday_slot_2": {
                         "name": "Søndag Slot 2",
                         "state": {
-                            "not enabled": "Ikke aktiveret",
-                            "not configured": "Ikke konfigureret"
+                            "not_enabled": "Ikke aktiveret",
+                            "not_configured": "Ikke konfigureret"
                         }
                     }
                 }
@@ -320,7 +320,7 @@
             "predictive_calendar_slots": {
                 "name": "SmartMowing-spærretider",
                 "state": {
-                    "manual calendar active": "Manuel kalender aktiv",
+                    "manual_calendar_active": "Manuel kalender aktiv",
                     "off": "Fra"
                 },
                 "state_attributes": {
@@ -336,25 +336,25 @@
                     "earliest_start": {
                         "name": "Tidligste start",
                         "state": {
-                            "not enabled": "Ikke aktiveret"
+                            "not_enabled": "Ikke aktiveret"
                         }
                     },
                     "latest_end": {
                         "name": "Seneste slut",
                         "state": {
-                            "not enabled": "Ikke aktiveret"
+                            "not_enabled": "Ikke aktiveret"
                         }
                     },
                     "blocked_before": {
                         "name": "Spærret før",
                         "state": {
-                            "not enabled": "Ikke aktiveret"
+                            "not_enabled": "Ikke aktiveret"
                         }
                     },
                     "blocked_after": {
                         "name": "Spærret efter",
                         "state": {
-                            "not enabled": "Ikke aktiveret"
+                            "not_enabled": "Ikke aktiveret"
                         }
                     }
                 }
@@ -362,7 +362,7 @@
             "predictive_schedule": {
                 "name": "SmartMowing-tidsplan",
                 "state": {
-                    "manual calendar active": "Manuel kalender aktiv",
+                    "manual_calendar_active": "Manuel kalender aktiv",
                     "none": "Ingen"
                 },
                 "state_attributes": {
@@ -397,7 +397,7 @@
                     "schedule_monday": {
                         "name": "Tidsplan Mandag",
                         "state": {
-                            "not scheduled": "Ikke planlagt"
+                            "not_scheduled": "Ikke planlagt"
                         }
                     },
                     "exclusion_monday_user": {
@@ -415,7 +415,7 @@
                     "schedule_tuesday": {
                         "name": "Tidsplan Tirsdag",
                         "state": {
-                            "not scheduled": "Ikke planlagt"
+                            "not_scheduled": "Ikke planlagt"
                         }
                     },
                     "exclusion_tuesday_user": {
@@ -433,7 +433,7 @@
                     "schedule_wednesday": {
                         "name": "Tidsplan Onsdag",
                         "state": {
-                            "not scheduled": "Ikke planlagt"
+                            "not_scheduled": "Ikke planlagt"
                         }
                     },
                     "exclusion_wednesday_user": {
@@ -451,7 +451,7 @@
                     "schedule_thursday": {
                         "name": "Tidsplan Torsdag",
                         "state": {
-                            "not scheduled": "Ikke planlagt"
+                            "not_scheduled": "Ikke planlagt"
                         }
                     },
                     "exclusion_thursday_user": {
@@ -469,7 +469,7 @@
                     "schedule_friday": {
                         "name": "Tidsplan Fredag",
                         "state": {
-                            "not scheduled": "Ikke planlagt"
+                            "not_scheduled": "Ikke planlagt"
                         }
                     },
                     "exclusion_friday_user": {
@@ -487,7 +487,7 @@
                     "schedule_saturday": {
                         "name": "Tidsplan Lørdag",
                         "state": {
-                            "not scheduled": "Ikke planlagt"
+                            "not_scheduled": "Ikke planlagt"
                         }
                     },
                     "exclusion_saturday_user": {
@@ -505,7 +505,7 @@
                     "schedule_sunday": {
                         "name": "Tidsplan Søndag",
                         "state": {
-                            "not scheduled": "Ikke planlagt"
+                            "not_scheduled": "Ikke planlagt"
                         }
                     },
                     "exclusion_sunday_user": {

--- a/custom_components/boschindego/translations/da.json
+++ b/custom_components/boschindego/translations/da.json
@@ -154,7 +154,7 @@
             "mowing_mode": {
                 "name": "Klippemode",
                 "state": {
-                    "Calendar": "Manuel kalender"
+                    "calendar": "Manuel kalender"
                 }
             },
             "runtime_total": {

--- a/custom_components/boschindego/translations/da.json
+++ b/custom_components/boschindego/translations/da.json
@@ -1,380 +1,709 @@
 {
-  "config": {
-    "abort": {
-      "already_configured": "Denne Bosch Indego-græsslåmaskine er allerede konfigureret!",
-      "connection_error": "Forbindelsen til Bosch Indego API-et mislykkedes! Kontroller venligst dokumentationen for kendte problemer for mulige løsninger.",
-      "no_mowers_found": "Ingen græsslåmaskiner fundet på denne Bosch Indego-konto!",
-      "reauth_successful": "Genautentificering var vellykket. Adgangen til Bosch API er blevet gendannet."
-    },
-    "step": {
-      "advanced": {
-        "data": {
-          "user_agent": "User-Agent",
-          "expose_mower": "Vis Indego-græsslåmaskinen som en mower-enhed i Home Assistant",
-          "expose_vacuum": "Vis Indego-græsslåmaskinen som en støvsuger-enhed i Home Assistant"
+    "config": {
+        "abort": {
+            "already_configured": "Denne Bosch Indego-græsslåmaskine er allerede konfigureret!",
+            "connection_error": "Forbindelsen til Bosch Indego API-et mislykkedes! Kontroller venligst dokumentationen for kendte problemer for mulige løsninger.",
+            "no_mowers_found": "Ingen græsslåmaskiner fundet på denne Bosch Indego-konto!",
+            "reauth_successful": "Genautentificering var vellykket. Adgangen til Bosch API er blevet gendannet."
         },
-        "data_description": {
-          "user_agent": "Brugerdefineret User-Agent header for API-anmodninger til Bosch Indego Cloud. Lad være tom for at bruge standard. Nogle brugere skal muligvis angive en brugerdefineret værdi, hvis deres konto har API-adgangsbegrænsninger."
-        },
-        "description": "Avancerede indstillinger for Bosch Indego-komponenten."
-      },
-      "mower": {
-        "data": {
-          "mower_serial": "Græsslåmaskine serienummer",
-          "mower_name": "Græsslåmaskine navn"
-        },
-        "description": "Vælg serienummeret på Bosch-græsslåmaskinen, som du vil tilføje."
-      },
-      "reauth_confirm": {
-        "title": "Autentificering udløbet",
-        "description": "Autentificeringen af Bosch Indego API'et er udløbet. Autentificer igen med dine Bosch SingleKey ID."
-      }
-    }
-  },
-  "options": {
-    "step": {
-      "init": {
-        "title": "Avancerede indstillinger",
-        "description": "Avancerede indstillinger for Bosch Indego-komponenten. Du skal muligvis genindlæse komponenten efter at have ændret disse indstillinger.",
-        "data": {
-          "user_agent": "User-Agent",
-          "expose_mower": "Vis Indego-græsslåmaskinen som en mower-enhed i Home Assistant",
-          "expose_vacuum": "Vis Indego-græsslåmaskinen som en støvsuger-enhed i Home Assistant",
-          "show_all_alerts": "Vis hele advarselshistorikken i Home Assistant. Dette anbefales ikke for de fleste brugere, da det kan have en væsentlig indvirkning på Home Assistant-databasens størrelse!"
-        },
-        "data_description": {
-          "user_agent": "Brugerdefineret User-Agent header for API-anmodninger til Bosch Indego Cloud. Lad være tom for at bruge standard. Nogle brugere skal muligvis angive en brugerdefineret værdi, hvis deres konto har API-adgangsbegrænsninger."
-        }
-      }
-    }
-  },
-  "entity": {
-    "binary_sensor": {
-      "indego_alert": {
-        "state_attributes": {
-          "alerts_count": {
-            "name": "Antal advarsler"
-          },
-          "last_alert_error_code": {
-            "name": "Fejlkode (seneste)"
-          },
-          "last_alert_message": {
-            "name": "Advarselskode (seneste)"
-          },
-          "last_alert_date": {
-            "name": "Advarselsdato (seneste)"
-          },
-          "last_alert_read": {
-            "name": "Advarselsstatuts (seneste)",
-            "state": {
-              "read": "Læst",
-              "unread": "Ulæst"
+        "step": {
+            "advanced": {
+                "data": {
+                    "user_agent": "User-Agent",
+                    "expose_mower": "Vis Indego-græsslåmaskinen som en mower-enhed i Home Assistant",
+                    "expose_vacuum": "Vis Indego-græsslåmaskinen som en støvsuger-enhed i Home Assistant"
+                },
+                "data_description": {
+                    "user_agent": "Brugerdefineret User-Agent header for API-anmodninger til Bosch Indego Cloud. Lad være tom for at bruge standard. Nogle brugere skal muligvis angive en brugerdefineret værdi, hvis deres konto har API-adgangsbegrænsninger."
+                },
+                "description": "Avancerede indstillinger for Bosch Indego-komponenten."
+            },
+            "mower": {
+                "data": {
+                    "mower_serial": "Græsslåmaskine serienummer",
+                    "mower_name": "Græsslåmaskine navn"
+                },
+                "description": "Vælg serienummeret på Bosch-græsslåmaskinen, som du vil tilføje."
+            },
+            "reauth_confirm": {
+                "title": "Autentificering udløbet",
+                "description": "Autentificeringen af Bosch Indego API'et er udløbet. Autentificer igen med dine Bosch SingleKey ID."
             }
-          }
         }
-      },
-      "online": {
-        "name": "Online"
-      },
-      "update_available": {
-        "name": "Opdatering tilgængelig"
-      },
-      "mower_stuck": {
-        "name": "Robot siddende fast"
-      },
-      "service_status": {
-        "name": "Servicestatus"
-      },
-      "battery_charging": {
-        "name": "Opladningsstatus"
-      }
     },
-    "sensor": {
-      "mower_state": {
-        "name": "Græsslåmaskinens tilstand",
-        "state": {
-          "mowing": "Slåning",
-          "docked": "Docket",
-          "sleeping": "Sover",
-          "paused": "Sat på pause"
+    "options": {
+        "step": {
+            "init": {
+                "title": "Avancerede indstillinger",
+                "description": "Avancerede indstillinger for Bosch Indego-komponenten. Du skal muligvis genindlæse komponenten efter at have ændret disse indstillinger.",
+                "data": {
+                    "user_agent": "User-Agent",
+                    "expose_mower": "Vis Indego-græsslåmaskinen som en mower-enhed i Home Assistant",
+                    "expose_vacuum": "Vis Indego-græsslåmaskinen som en støvsuger-enhed i Home Assistant",
+                    "show_all_alerts": "Vis hele advarselshistorikken i Home Assistant. Dette anbefales ikke for de fleste brugere, da det kan have en væsentlig indvirkning på Home Assistant-databasens størrelse!"
+                },
+                "data_description": {
+                    "user_agent": "Brugerdefineret User-Agent header for API-anmodninger til Bosch Indego Cloud. Lad være tom for at bruge standard. Nogle brugere skal muligvis angive en brugerdefineret værdi, hvis deres konto har API-adgangsbegrænsninger."
+                }
+            }
         }
-      },
-      "mower_state_detail": {
-        "name": "Detaljer om plæneklipperens tilstand",
-        "state": {
-          "reading_status": "Læser status",
-          "charging": "Oplader",
-          "docked": "Docket",
-          "sleeping": "Sover",
-          "docked_software_update": "Docket - Softwareopdatering",
-          "docked_loading_map": "Docket - Indlæser kort",
-          "docked_saving_map": "Docket - Gemmer kort",
-          "docked_leaving_dock": "Docket - Forlader dockingstationen",
-          "mowing": "Slåning",
-          "mowing_relocalising": "Slåning - Genpositionering",
-          "mowing_learning_lawn": "Slåning - Lærer græsplænen",
-          "mowing_learning_lawn_paused": "Slåning - Læring af græsplæne sat på pause",
-          "spotmow": "SpotMow",
-          "mowing_randomly": "Slår tilfældigt",
-          "diagnostic_mode": "Diagnostisk tilstand",
-          "end_of_life": "Levetidsslut",
-          "software_update": "Softwareopdatering",
-          "energy_save_mode": "Energisparingstilstand",
-          "relocalising": "Genpositionering",
-          "loading_map": "Indlæser kort",
-          "learning_lawn": "Lærer græsplænen",
-          "paused": "Sat på pause",
-          "border_cut": "Kantklip",
-          "idle_in_lawn": "Inaktiv på græsplænen",
-          "stuck_on_lawn_help_needed": "Fanget på græsplænen, hjælp behøves",
-          "returning_to_dock": "Vender tilbage til dockingstationen",
-          "returning_to_dock_battery_low": "Vender tilbage til dockingstationen - Lavt batteri",
-          "returning_to_dock_calendar_timeslot_ended": "Vender tilbage til dockingstationen - Kalender-tidsslot sluttede",
-          "returning_to_dock_battery_temp_range": "Vender tilbage til dockingstationen - Batteritemperaturinterval",
-          "returning_to_dock_lawn_complete": "Vender tilbage til dockingstationen - Græsplæne fuldstændig slået",
-          "returning_to_dock_relocalising": "Vender tilbage til dockingstationen - Genpositionering",
-          "returning_to_dock_requested_by_user_app": "Vender tilbage til dockingstationen - Anmodet af bruger/app"
-        }
-      },
-      "battery_percentage": {
-        "name": "Batteri"
-      },
-      "lawn_mowed": {
-        "name": "Plæne klippet"
-      },
-      "lawn_mowed_size": {
-        "name": "Plæneareal klippet"
-      },
-      "last_completed": {
-        "name": "Senest afsluttet"
-      },
-      "next_mow": {
-        "name": "Næste klipning"
-      },
-      "mowing_mode": {
-        "name": "Klippemode"
-      },
-      "runtime_total": {
-        "name": "Total klipningstid"
-      },
-      "garden_size": {
-        "name": "Havestørrelse"
-      },
-      "mower_position_x": {
-        "name": "Robot position X"
-      },
-      "mower_position_y": {
-        "name": "Robot position Y"
-      },
-      "last_error_code": {
-        "name": "Seneste fejl"
-      },
-      "firmware_version": {
-        "name": "Firmwareversion"
-      },
-      "maintenance_hours": {
-        "name": "Vedligeholdelsesbetjentid"
-      },
-      "session_count": {
-        "name": "Sessionsantal"
-      },
-      "battery_voltage": {
-        "name": "Batterimoduler"
-      },
-      "battery_temperature": {
-        "name": "BatteriTemperatur"
-      },
-      "ambient_temperature": {
-        "name": "Omgivelsestemperatur"
-      },
-      "battery_cycles": {
-        "name": "Batterikræv"
-      },
-      "battery_discharge": {
-        "name": "Batteriudladning"
-      }
     },
-    "camera": {
-      "mowing_map": {
-        "name": "Klippekort"
-      }
-    },
-    "button": {
-      "delete_all_alerts": {
-        "name": "Slet alle advarsler"
-      },
-      "delete_last_alert": {
-        "name": "Slet seneste advarsel"
-      },
-      "read_all_alerts": {
-        "name": "Markér alle advarsler som læst"
-      },
-      "read_last_alert": {
-        "name": "Markér seneste advarsel som læst"
-      }
-    },
-    "switch": {
-      "indego_smartmowing": {
-        "name": "SmartMowing"
-      }
-    }
-  },
-  "services": {
-    "command": {
-      "name": "Send kommando",
-      "description": "Send kommandoer til græsslåmaskinen. Vælg en kommando.",
-      "fields": {
-        "mower_serial": {
-          "name": "Serienummer",
-          "description": "Græsslåmaskine serienummer. Kun nødvendigt, når du har konfigureret flere græsslåmaskiner."
+    "entity": {
+        "binary_sensor": {
+            "indego_alert": {
+                "state_attributes": {
+                    "alerts_count": {
+                        "name": "Antal advarsler"
+                    },
+                    "last_alert_error_code": {
+                        "name": "Fejlkode (seneste)"
+                    },
+                    "last_alert_message": {
+                        "name": "Advarselskode (seneste)"
+                    },
+                    "last_alert_date": {
+                        "name": "Advarselsdato (seneste)"
+                    },
+                    "last_alert_read": {
+                        "name": "Advarselsstatuts (seneste)",
+                        "state": {
+                            "read": "Læst",
+                            "unread": "Ulæst"
+                        }
+                    }
+                }
+            },
+            "online": {
+                "name": "Online"
+            },
+            "update_available": {
+                "name": "Opdatering tilgængelig"
+            },
+            "mower_stuck": {
+                "name": "Robot siddende fast"
+            },
+            "service_status": {
+                "name": "Servicestatus"
+            },
+            "battery_charging": {
+                "name": "Opladningsstatus"
+            }
         },
+        "sensor": {
+            "mower_state": {
+                "name": "Græsslåmaskinens tilstand",
+                "state": {
+                    "mowing": "Slåning",
+                    "docked": "Docket",
+                    "sleeping": "Sover",
+                    "paused": "Sat på pause"
+                }
+            },
+            "mower_state_detail": {
+                "name": "Detaljer om plæneklipperens tilstand",
+                "state": {
+                    "reading_status": "Læser status",
+                    "charging": "Oplader",
+                    "docked": "Docket",
+                    "sleeping": "Sover",
+                    "docked_software_update": "Docket - Softwareopdatering",
+                    "docked_loading_map": "Docket - Indlæser kort",
+                    "docked_saving_map": "Docket - Gemmer kort",
+                    "docked_leaving_dock": "Docket - Forlader dockingstationen",
+                    "mowing": "Slåning",
+                    "mowing_relocalising": "Slåning - Genpositionering",
+                    "mowing_learning_lawn": "Slåning - Lærer græsplænen",
+                    "mowing_learning_lawn_paused": "Slåning - Læring af græsplæne sat på pause",
+                    "spotmow": "SpotMow",
+                    "mowing_randomly": "Slår tilfældigt",
+                    "diagnostic_mode": "Diagnostisk tilstand",
+                    "end_of_life": "Levetidsslut",
+                    "software_update": "Softwareopdatering",
+                    "energy_save_mode": "Energisparingstilstand",
+                    "relocalising": "Genpositionering",
+                    "loading_map": "Indlæser kort",
+                    "learning_lawn": "Lærer græsplænen",
+                    "paused": "Sat på pause",
+                    "border_cut": "Kantklip",
+                    "idle_in_lawn": "Inaktiv på græsplænen",
+                    "stuck_on_lawn_help_needed": "Fanget på græsplænen, hjælp behøves",
+                    "returning_to_dock": "Vender tilbage til dockingstationen",
+                    "returning_to_dock_battery_low": "Vender tilbage til dockingstationen - Lavt batteri",
+                    "returning_to_dock_calendar_timeslot_ended": "Vender tilbage til dockingstationen - Kalender-tidsslot sluttede",
+                    "returning_to_dock_battery_temp_range": "Vender tilbage til dockingstationen - Batteritemperaturinterval",
+                    "returning_to_dock_lawn_complete": "Vender tilbage til dockingstationen - Græsplæne fuldstændig slået",
+                    "returning_to_dock_relocalising": "Vender tilbage til dockingstationen - Genpositionering",
+                    "returning_to_dock_requested_by_user_app": "Vender tilbage til dockingstationen - Anmodet af bruger/app"
+                }
+            },
+            "battery_percentage": {
+                "name": "Batteri"
+            },
+            "lawn_mowed": {
+                "name": "Plæne klippet"
+            },
+            "lawn_mowed_size": {
+                "name": "Plæneareal klippet"
+            },
+            "last_completed": {
+                "name": "Senest afsluttet"
+            },
+            "next_mow": {
+                "name": "Næste klipning"
+            },
+            "mowing_mode": {
+                "name": "Klippemode",
+                "state": {
+                    "Calendar": "Manuel kalender"
+                }
+            },
+            "runtime_total": {
+                "name": "Total klipningstid"
+            },
+            "garden_size": {
+                "name": "Havestørrelse"
+            },
+            "mower_position_x": {
+                "name": "Robot position X"
+            },
+            "mower_position_y": {
+                "name": "Robot position Y"
+            },
+            "last_error_code": {
+                "name": "Seneste fejl"
+            },
+            "firmware_version": {
+                "name": "Firmwareversion"
+            },
+            "maintenance_hours": {
+                "name": "Vedligeholdelsesbetjentid"
+            },
+            "session_count": {
+                "name": "Sessionsantal"
+            },
+            "battery_voltage": {
+                "name": "Batterimoduler"
+            },
+            "battery_temperature": {
+                "name": "BatteriTemperatur"
+            },
+            "ambient_temperature": {
+                "name": "Omgivelsestemperatur"
+            },
+            "battery_cycles": {
+                "name": "Batterikræv"
+            },
+            "battery_discharge": {
+                "name": "Batteriudladning"
+            },
+            "calendar_slots": {
+                "state": {
+                    "SmartMowing active": "SmartMowing aktiv",
+                    "off": "Fra"
+                },
+                "name": "Planlagte klippetider",
+                "state_attributes": {
+                    "today_slot_1": {
+                        "name": "I dag slot 1",
+                        "state": {
+                            "not enabled": "Ikke aktiveret",
+                            "not configured": "Ikke konfigureret"
+                        }
+                    },
+                    "today_slot_2": {
+                        "name": "I dag slot 2",
+                        "state": {
+                            "not enabled": "Ikke aktiveret",
+                            "not configured": "Ikke konfigureret"
+                        }
+                    },
+                    "monday_slot_1": {
+                        "name": "Mandag Slot 1",
+                        "state": {
+                            "not enabled": "Ikke aktiveret",
+                            "not configured": "Ikke konfigureret"
+                        }
+                    },
+                    "monday_slot_2": {
+                        "name": "Mandag Slot 2",
+                        "state": {
+                            "not enabled": "Ikke aktiveret",
+                            "not configured": "Ikke konfigureret"
+                        }
+                    },
+                    "tuesday_slot_1": {
+                        "name": "Tirsdag Slot 1",
+                        "state": {
+                            "not enabled": "Ikke aktiveret",
+                            "not configured": "Ikke konfigureret"
+                        }
+                    },
+                    "tuesday_slot_2": {
+                        "name": "Tirsdag Slot 2",
+                        "state": {
+                            "not enabled": "Ikke aktiveret",
+                            "not configured": "Ikke konfigureret"
+                        }
+                    },
+                    "wednesday_slot_1": {
+                        "name": "Onsdag Slot 1",
+                        "state": {
+                            "not enabled": "Ikke aktiveret",
+                            "not configured": "Ikke konfigureret"
+                        }
+                    },
+                    "wednesday_slot_2": {
+                        "name": "Onsdag Slot 2",
+                        "state": {
+                            "not enabled": "Ikke aktiveret",
+                            "not configured": "Ikke konfigureret"
+                        }
+                    },
+                    "thursday_slot_1": {
+                        "name": "Torsdag Slot 1",
+                        "state": {
+                            "not enabled": "Ikke aktiveret",
+                            "not configured": "Ikke konfigureret"
+                        }
+                    },
+                    "thursday_slot_2": {
+                        "name": "Torsdag Slot 2",
+                        "state": {
+                            "not enabled": "Ikke aktiveret",
+                            "not configured": "Ikke konfigureret"
+                        }
+                    },
+                    "friday_slot_1": {
+                        "name": "Fredag Slot 1",
+                        "state": {
+                            "not enabled": "Ikke aktiveret",
+                            "not configured": "Ikke konfigureret"
+                        }
+                    },
+                    "friday_slot_2": {
+                        "name": "Fredag Slot 2",
+                        "state": {
+                            "not enabled": "Ikke aktiveret",
+                            "not configured": "Ikke konfigureret"
+                        }
+                    },
+                    "saturday_slot_1": {
+                        "name": "Lørdag Slot 1",
+                        "state": {
+                            "not enabled": "Ikke aktiveret",
+                            "not configured": "Ikke konfigureret"
+                        }
+                    },
+                    "saturday_slot_2": {
+                        "name": "Lørdag Slot 2",
+                        "state": {
+                            "not enabled": "Ikke aktiveret",
+                            "not configured": "Ikke konfigureret"
+                        }
+                    },
+                    "sunday_slot_1": {
+                        "name": "Søndag Slot 1",
+                        "state": {
+                            "not enabled": "Ikke aktiveret",
+                            "not configured": "Ikke konfigureret"
+                        }
+                    },
+                    "sunday_slot_2": {
+                        "name": "Søndag Slot 2",
+                        "state": {
+                            "not enabled": "Ikke aktiveret",
+                            "not configured": "Ikke konfigureret"
+                        }
+                    }
+                }
+            },
+            "predictive_calendar_slots": {
+                "name": "SmartMowing-spærretider",
+                "state": {
+                    "Manual calendar active": "Manuel kalender aktiv",
+                    "off": "Fra"
+                },
+                "state_attributes": {
+                    "last_updated": {
+                        "name": "Sidst opdateret"
+                    },
+                    "smartmowing_enabled": {
+                        "name": "SmartMowing aktiv"
+                    },
+                    "mowing_mode": {
+                        "name": "Klippetilstand"
+                    },
+                    "earliest_start": {
+                        "name": "Tidligste start",
+                        "state": {
+                            "not enabled": "Ikke aktiveret"
+                        }
+                    },
+                    "latest_end": {
+                        "name": "Seneste slut",
+                        "state": {
+                            "not enabled": "Ikke aktiveret"
+                        }
+                    },
+                    "blocked_before": {
+                        "name": "Spærret før",
+                        "state": {
+                            "not enabled": "Ikke aktiveret"
+                        }
+                    },
+                    "blocked_after": {
+                        "name": "Spærret efter",
+                        "state": {
+                            "not enabled": "Ikke aktiveret"
+                        }
+                    }
+                }
+            },
+            "predictive_schedule": {
+                "name": "SmartMowing-tidsplan",
+                "state": {
+                    "Manual calendar active": "Manuel kalender aktiv",
+                    "none": "Ingen"
+                },
+                "state_attributes": {
+                    "last_updated": {
+                        "name": "Sidst opdateret"
+                    },
+                    "next_mow_slot": {
+                        "name": "Næste planlagte klippeslot",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "next_mow_day": {
+                        "name": "Næste planlagte klippedag",
+                        "state": {
+                            "none": "Ingen",
+                            "monday": "Mandag",
+                            "tuesday": "Tirsdag",
+                            "wednesday": "Onsdag",
+                            "thursday": "Torsdag",
+                            "friday": "Fredag",
+                            "saturday": "Lørdag",
+                            "sunday": "Søndag"
+                        }
+                    },
+                    "next_mow_time": {
+                        "name": "Næste planlagte klippetid",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "schedule_monday": {
+                        "name": "Tidsplan Mandag",
+                        "state": {
+                            "not scheduled": "Ikke planlagt"
+                        }
+                    },
+                    "exclusion_monday_user": {
+                        "name": "Spærretid Mandag bruger",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "exclusion_monday_weather": {
+                        "name": "Spærretid Mandag vejr",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "schedule_tuesday": {
+                        "name": "Tidsplan Tirsdag",
+                        "state": {
+                            "not scheduled": "Ikke planlagt"
+                        }
+                    },
+                    "exclusion_tuesday_user": {
+                        "name": "Spærretid Tirsdag bruger",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "exclusion_tuesday_weather": {
+                        "name": "Spærretid Tirsdag vejr",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "schedule_wednesday": {
+                        "name": "Tidsplan Onsdag",
+                        "state": {
+                            "not scheduled": "Ikke planlagt"
+                        }
+                    },
+                    "exclusion_wednesday_user": {
+                        "name": "Spærretid Onsdag bruger",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "exclusion_wednesday_weather": {
+                        "name": "Spærretid Onsdag vejr",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "schedule_thursday": {
+                        "name": "Tidsplan Torsdag",
+                        "state": {
+                            "not scheduled": "Ikke planlagt"
+                        }
+                    },
+                    "exclusion_thursday_user": {
+                        "name": "Spærretid Torsdag bruger",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "exclusion_thursday_weather": {
+                        "name": "Spærretid Torsdag vejr",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "schedule_friday": {
+                        "name": "Tidsplan Fredag",
+                        "state": {
+                            "not scheduled": "Ikke planlagt"
+                        }
+                    },
+                    "exclusion_friday_user": {
+                        "name": "Spærretid Fredag bruger",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "exclusion_friday_weather": {
+                        "name": "Spærretid Fredag vejr",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "schedule_saturday": {
+                        "name": "Tidsplan Lørdag",
+                        "state": {
+                            "not scheduled": "Ikke planlagt"
+                        }
+                    },
+                    "exclusion_saturday_user": {
+                        "name": "Spærretid Lørdag bruger",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "exclusion_saturday_weather": {
+                        "name": "Spærretid Lørdag vejr",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "schedule_sunday": {
+                        "name": "Tidsplan Søndag",
+                        "state": {
+                            "not scheduled": "Ikke planlagt"
+                        }
+                    },
+                    "exclusion_sunday_user": {
+                        "name": "Spærretid Søndag bruger",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "exclusion_sunday_weather": {
+                        "name": "Spærretid Søndag vejr",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    }
+                }
+            }
+        },
+        "camera": {
+            "mowing_map": {
+                "name": "Klippekort"
+            }
+        },
+        "button": {
+            "delete_all_alerts": {
+                "name": "Slet alle advarsler"
+            },
+            "delete_last_alert": {
+                "name": "Slet seneste advarsel"
+            },
+            "read_all_alerts": {
+                "name": "Markér alle advarsler som læst"
+            },
+            "read_last_alert": {
+                "name": "Markér seneste advarsel som læst"
+            }
+        },
+        "switch": {
+            "indego_smartmowing": {
+                "name": "SmartMowing"
+            }
+        }
+    },
+    "services": {
         "command": {
-          "name": "Send kommando",
-          "description": "Send kommandoer til græsslåmaskinen. Vælg en kommando."
+            "name": "Send kommando",
+            "description": "Send kommandoer til græsslåmaskinen. Vælg en kommando.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Serienummer",
+                    "description": "Græsslåmaskine serienummer. Kun nødvendigt, når du har konfigureret flere græsslåmaskiner."
+                },
+                "command": {
+                    "name": "Send kommando",
+                    "description": "Send kommandoer til græsslåmaskinen. Vælg en kommando."
+                }
+            }
+        },
+        "smartmowing": {
+            "name": "Skift SmartMowing",
+            "description": "Aktivér eller deaktivér SmartMowing. Tilladte værdier er true eller false.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Serienummer",
+                    "description": "Græsslåmaskine serienummer. Kun nødvendigt, når du har konfigureret flere græsslåmaskiner."
+                },
+                "enable": {
+                    "name": "Aktivér",
+                    "description": "Aktivér SmartMowing."
+                }
+            }
+        },
+        "delete_alert": {
+            "name": "Slet advarsel",
+            "description": "Slet den valgte advarsel.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Serienummer",
+                    "description": "Græsslåmaskine serienummer. Kun nødvendigt, når du har konfigureret flere græsslåmaskiner."
+                },
+                "alert_index": {
+                    "name": "Advarselsindeks",
+                    "description": "Slet den valgte advarsel. 0 for den seneste advarsel."
+                }
+            }
+        },
+        "delete_alert_all": {
+            "name": "Slet alle advarsler",
+            "description": "Slet alle advarsler.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Serienummer",
+                    "description": "Græsslåmaskine serienummer. Kun nødvendigt, når du har konfigureret flere græsslåmaskiner."
+                }
+            }
+        },
+        "read_alert": {
+            "name": "Marker advarsel som læst",
+            "description": "Markér den valgte advarsel som læst.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Serienummer",
+                    "description": "Græsslåmaskine serienummer. Kun nødvendigt, når du har konfigureret flere græsslåmaskiner."
+                },
+                "alert_index": {
+                    "name": "Advarselsindeks",
+                    "description": "Markér den valgte advarsel som læst. 0 for den seneste advarsel."
+                }
+            }
+        },
+        "read_alert_all": {
+            "name": "Marker alle advarsler som læst",
+            "description": "Markér alle advarsler som læste.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Serienummer",
+                    "description": "Græsslåmaskine serienummer. Kun nødvendigt, når du har konfigureret flere græsslåmaskiner."
+                }
+            }
+        },
+        "download_map": {
+            "name": "Download klippekort",
+            "description": "Henter det aktuelle slåningskort fra Bosch Cloud API'en og gemmer det lokalt som \"www/indego_map_base.svg\". Kortet afspejler den senest optegnede slåningsrute.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Serienummer",
+                    "description": "Græsslåmaskine serienummer. Kun nødvendigt, når du har konfigureret flere græsslåmaskiner."
+                }
+            }
+        },
+        "set_calendar_slot": {
+            "name": "Aktivér/deaktivér kalender-slot",
+            "description": "Rediger en kalender-slot (ændr tider, aktivér eller deaktivér)",
+            "fields": {
+                "mower_serial": {
+                    "name": "Serienummer",
+                    "description": "Serienummer på plæneklipperen. Kun nødvendig, hvis der er konfigureret flere plæneklippere."
+                },
+                "calendar_type": {
+                    "name": "Kalendertype",
+                    "description": "Vælg kalender ('calendar' for manuel kalender oder 'predictive' for deaktiverede tidsrum i SmartMowing-tilstand)."
+                },
+                "day": {
+                    "name": "Dag",
+                    "description": "Navnet på den ugedag, der skal konfigureres."
+                },
+                "slot": {
+                    "name": "Tidsslot",
+                    "description": "Hvilken tidsslot skal ændres (1 eller 2)."
+                },
+                "enabled": {
+                    "name": "Aktivér/deaktivér",
+                    "description": "Aktivér eller deaktivér den valgte dag/slot."
+                },
+                "start": {
+                    "name": "Start",
+                    "description": "Starttidspunkt for den valgte slot. Kun nødvendigt hvis slotten skal aktiveres. Kun timer og minutter anvendes."
+                },
+                "end": {
+                    "name": "Slut",
+                    "description": "Sluttidspunkt for den valgte slot. Kun nødvendigt hvis slotten skal aktiveres. Kun timer og minutter anvendes."
+                }
+            }
         }
-      }
     },
-    "smartmowing": {
-      "name": "Skift SmartMowing",
-      "description": "Aktivér eller deaktivér SmartMowing. Tilladte værdier er true eller false.",
-      "fields": {
-        "mower_serial": {
-          "name": "Serienummer",
-          "description": "Græsslåmaskine serienummer. Kun nødvendigt, når du har konfigureret flere græsslåmaskiner."
+    "selector": {
+        "calendar_type_options": {
+            "options": {
+                "calendar": "Manuel kalender",
+                "predictive": "SmartMowing-spærretider"
+            }
         },
-        "enable": {
-          "name": "Aktivér",
-          "description": "Aktivér SmartMowing."
+        "day_options": {
+            "options": {
+                "monday": "Mandag",
+                "tuesday": "Tirsdag",
+                "wednesday": "Onsdag",
+                "thursday": "Torsdag",
+                "friday": "Fredag",
+                "saturday": "Lørdag",
+                "sunday": "Søndag"
+            }
+        },
+        "command_options": {
+            "options": {
+                "mow": "Klip græs",
+                "return_to_dock": "Tilbage til ladestationen",
+                "pause": "Pause"
+            }
         }
-      }
     },
-    "delete_alert": {
-      "name": "Slet advarsel",
-      "description": "Slet den valgte advarsel.",
-      "fields": {
-        "mower_serial": {
-          "name": "Serienummer",
-          "description": "Græsslåmaskine serienummer. Kun nødvendigt, når du har konfigureret flere græsslåmaskiner."
+    "issues": {
+        "auth_failure": {
+            "title": "Bosch Indego authentication expired",
+            "description": "Your authentication with Bosch Indego has expired. Please go to Settings > Devices & Services > Indego > Re-authenticate to restore access to your mower."
         },
-        "alert_index": {
-          "name": "Advarselsindeks",
-          "description": "Slet den valgte advarsel. 0 for den seneste advarsel."
+        "connection_failure": {
+            "title": "Bosch Indego connection problems",
+            "description": "Your mower has not responded to API requests for an extended period. This may indicate network issues, the Bosch service is experiencing problems, or your mower is offline. Please check your internet connection and mower status."
         }
-      }
-    },
-    "delete_alert_all": {
-      "name": "Slet alle advarsler",
-      "description": "Slet alle advarsler.",
-      "fields": {
-        "mower_serial": {
-          "name": "Serienummer",
-          "description": "Græsslåmaskine serienummer. Kun nødvendigt, når du har konfigureret flere græsslåmaskiner."
-        }
-      }
-    },
-    "read_alert": {
-      "name": "Marker advarsel som læst",
-      "description": "Markér den valgte advarsel som læst.",
-      "fields": {
-        "mower_serial": {
-          "name": "Serienummer",
-          "description": "Græsslåmaskine serienummer. Kun nødvendigt, når du har konfigureret flere græsslåmaskiner."
-        },
-        "alert_index": {
-          "name": "Advarselsindeks",
-          "description": "Markér den valgte advarsel som læst. 0 for den seneste advarsel."
-        }
-      }
-    },
-    "read_alert_all": {
-      "name": "Marker alle advarsler som læst",
-      "description": "Markér alle advarsler som læste.",
-      "fields": {
-        "mower_serial": {
-          "name": "Serienummer",
-          "description": "Græsslåmaskine serienummer. Kun nødvendigt, når du har konfigureret flere græsslåmaskiner."
-        }
-      }
-    },
-    "download_map": {
-      "name": "Download klippekort",
-      "description": "Henter det aktuelle slåningskort fra Bosch Cloud API'en og gemmer det lokalt som \"www/indego_map_base.svg\". Kortet afspejler den senest optegnede slåningsrute.",
-      "fields": {
-        "mower_serial": {
-          "name": "Serienummer",
-          "description": "Græsslåmaskine serienummer. Kun nødvendigt, når du har konfigureret flere græsslåmaskiner."
-        }
-      }
-    },
-    "set_calendar_slot": {
-      "name": "Aktivér/deaktivér kalender-slot",
-      "description": "Rediger en kalender-slot (ændr tider, aktivér eller deaktivér)",
-      "fields": {
-        "mower_serial": {
-          "name": "Serienummer",
-          "description": "Serienummer på plæneklipperen. Kun nødvendig, hvis der er konfigureret flere plæneklippere."
-        },
-        "calendar_type": {
-          "name": "Kalendertype",
-          "description": "Vælg kalender ('calendar' for manuel kalender oder 'predictive' for deaktiverede tidsrum i SmartMowing-tilstand)."
-        },
-        "day": {
-          "name": "Dag",
-          "description": "Navnet på den ugedag, der skal konfigureres."
-        },
-        "slot": {
-          "name": "Tidsslot",
-          "description": "Hvilken tidsslot skal ændres (1 eller 2)."
-        },
-        "enabled": {
-          "name": "Aktivér/deaktivér",
-          "description": "Aktivér eller deaktivér den valgte dag/slot."
-        },
-        "start": {
-          "name": "Start",
-          "description": "Starttidspunkt for den valgte slot. Kun nødvendigt hvis slotten skal aktiveres. Kun timer og minutter anvendes."
-        },
-        "end": {
-          "name": "Slut",
-          "description": "Sluttidspunkt for den valgte slot. Kun nødvendigt hvis slotten skal aktiveres. Kun timer og minutter anvendes."
-        }
-      }
     }
-  },
-  "selector": {
-    "calendar_type_options": {
-      "options": {
-        "calendar": "Manuel kalender",
-        "predictive": "SmartMowing-spærretider"
-      }
-    },
-    "day_options": {
-      "options": {
-        "monday": "Mandag",
-        "tuesday": "Tirsdag",
-        "wednesday": "Onsdag",
-        "thursday": "Torsdag",
-        "friday": "Fredag",
-        "saturday": "Lørdag",
-        "sunday": "Søndag"
-      }
-    },
-    "command_options": {
-      "options": {
-        "mow": "Klip græs",
-        "return_to_dock": "Tilbage til ladestationen",
-        "pause": "Pause"
-      }
-    }
-  },
-  "issues": {
-    "auth_failure": {
-      "title": "Bosch Indego authentication expired",
-      "description": "Your authentication with Bosch Indego has expired. Please go to Settings > Devices & Services > Indego > Re-authenticate to restore access to your mower."
-    },
-    "connection_failure": {
-      "title": "Bosch Indego connection problems",
-      "description": "Your mower has not responded to API requests for an extended period. This may indicate network issues, the Bosch service is experiencing problems, or your mower is offline. Please check your internet connection and mower status."
-    }
-  }
 }

--- a/custom_components/boschindego/translations/da.json
+++ b/custom_components/boschindego/translations/da.json
@@ -198,7 +198,7 @@
             },
             "calendar_slots": {
                 "state": {
-                    "SmartMowing active": "SmartMowing aktiv",
+                    "smartmowing active": "SmartMowing aktiv",
                     "off": "Fra"
                 },
                 "name": "Planlagte klippetider",
@@ -320,7 +320,7 @@
             "predictive_calendar_slots": {
                 "name": "SmartMowing-spærretider",
                 "state": {
-                    "Manual calendar active": "Manuel kalender aktiv",
+                    "manual calendar active": "Manuel kalender aktiv",
                     "off": "Fra"
                 },
                 "state_attributes": {
@@ -362,7 +362,7 @@
             "predictive_schedule": {
                 "name": "SmartMowing-tidsplan",
                 "state": {
-                    "Manual calendar active": "Manuel kalender aktiv",
+                    "manual calendar active": "Manuel kalender aktiv",
                     "none": "Ingen"
                 },
                 "state_attributes": {

--- a/custom_components/boschindego/translations/de.json
+++ b/custom_components/boschindego/translations/de.json
@@ -199,7 +199,7 @@
             "predictive_calendar_slots": {
                 "name": "SmartMowing Sperrzeiten",
                 "state": {
-                    "manual calendar active": "Manueller Kalender aktiv",
+                    "manual_calendar_active": "Manueller Kalender aktiv",
                     "off": "Aus"
                 },
                 "state_attributes": {
@@ -215,25 +215,25 @@
                     "earliest_start": {
                         "name": "Frühester Start",
                         "state": {
-                            "not enabled": "Nicht aktiviert"
+                            "not_enabled": "Nicht aktiviert"
                         }
                     },
                     "latest_end": {
                         "name": "Spätestes Ende",
                         "state": {
-                            "not enabled": "Nicht aktiviert"
+                            "not_enabled": "Nicht aktiviert"
                         }
                     },
                     "blocked_before": {
                         "name": "Gesperrt vor",
                         "state": {
-                            "not enabled": "Nicht aktiviert"
+                            "not_enabled": "Nicht aktiviert"
                         }
                     },
                     "blocked_after": {
                         "name": "Gesperrt nach",
                         "state": {
-                            "not enabled": "Nicht aktiviert"
+                            "not_enabled": "Nicht aktiviert"
                         }
                     }
                 }
@@ -241,7 +241,7 @@
             "predictive_schedule": {
                 "name": "SmartMowing Zeitplan",
                 "state": {
-                    "manual calendar active": "Manueller Kalender aktiv",
+                    "manual_calendar_active": "Manueller Kalender aktiv",
                     "none": "Keine"
                 },
                 "state_attributes": {
@@ -276,43 +276,43 @@
                     "schedule_monday": {
                         "name": "Zeitplan Montag",
                         "state": {
-                            "not scheduled": "Nicht geplant"
+                            "not_scheduled": "Nicht geplant"
                         }
                     },
                     "schedule_tuesday": {
                         "name": "Zeitplan Dienstag",
                         "state": {
-                            "not scheduled": "Nicht geplant"
+                            "not_scheduled": "Nicht geplant"
                         }
                     },
                     "schedule_wednesday": {
                         "name": "Zeitplan Mittwoch",
                         "state": {
-                            "not scheduled": "Nicht geplant"
+                            "not_scheduled": "Nicht geplant"
                         }
                     },
                     "schedule_thursday": {
                         "name": "Zeitplan Donnerstag",
                         "state": {
-                            "not scheduled": "Nicht geplant"
+                            "not_scheduled": "Nicht geplant"
                         }
                     },
                     "schedule_friday": {
                         "name": "Zeitplan Freitag",
                         "state": {
-                            "not scheduled": "Nicht geplant"
+                            "not_scheduled": "Nicht geplant"
                         }
                     },
                     "schedule_saturday": {
                         "name": "Zeitplan Samstag",
                         "state": {
-                            "not scheduled": "Nicht geplant"
+                            "not_scheduled": "Nicht geplant"
                         }
                     },
                     "schedule_sunday": {
                         "name": "Zeitplan Sonntag",
                         "state": {
-                            "not scheduled": "Nicht geplant"
+                            "not_scheduled": "Nicht geplant"
                         }
                     },
                     "exclusion_monday_user": {
@@ -404,120 +404,120 @@
             "calendar_slots": {
                 "name": "Geplante Mähzeiten",
                 "state": {
-                    "SmartMowing active": "SmartMowing aktiv",
+                    "smartmowing_active": "SmartMowing aktiv",
                     "off": "Aus"
                 },
                 "state_attributes": {
                     "today_slot_1": {
                         "name": "Heute Slot 1",
                         "state": {
-                            "not enabled": "Nicht aktiviert",
-                            "not configured": "Nicht konfiguriert"
+                            "not_enabled": "Nicht aktiviert",
+                            "not_configured": "Nicht konfiguriert"
                         }
                     },
                     "today_slot_2": {
                         "name": "Heute Slot 2",
                         "state": {
-                            "not enabled": "Nicht aktiviert",
-                            "not configured": "Nicht konfiguriert"
+                            "not_enabled": "Nicht aktiviert",
+                            "not_configured": "Nicht konfiguriert"
                         }
                     },
                     "monday_slot_1": {
                         "name": "Montag Slot 1",
                         "state": {
-                            "not enabled": "Nicht aktiviert",
-                            "not configured": "Nicht konfiguriert"
+                            "not_enabled": "Nicht aktiviert",
+                            "not_configured": "Nicht konfiguriert"
                         }
                     },
                     "monday_slot_2": {
                         "name": "Montag Slot 2",
                         "state": {
-                            "not enabled": "Nicht aktiviert",
-                            "not configured": "Nicht konfiguriert"
+                            "not_enabled": "Nicht aktiviert",
+                            "not_configured": "Nicht konfiguriert"
                         }
                     },
                     "tuesday_slot_1": {
                         "name": "Dienstag Slot 1",
                         "state": {
-                            "not enabled": "Nicht aktiviert",
-                            "not configured": "Nicht konfiguriert"
+                            "not_enabled": "Nicht aktiviert",
+                            "not_configured": "Nicht konfiguriert"
                         }
                     },
                     "tuesday_slot_2": {
                         "name": "Dienstag Slot 2",
                         "state": {
-                            "not enabled": "Nicht aktiviert",
-                            "not configured": "Nicht konfiguriert"
+                            "not_enabled": "Nicht aktiviert",
+                            "not_configured": "Nicht konfiguriert"
                         }
                     },
                     "wednesday_slot_1": {
                         "name": "Mittwoch Slot 1",
                         "state": {
-                            "not enabled": "Nicht aktiviert",
-                            "not configured": "Nicht konfiguriert"
+                            "not_enabled": "Nicht aktiviert",
+                            "not_configured": "Nicht konfiguriert"
                         }
                     },
                     "wednesday_slot_2": {
                         "name": "Mittwoch Slot 2",
                         "state": {
-                            "not enabled": "Nicht aktiviert",
-                            "not configured": "Nicht konfiguriert"
+                            "not_enabled": "Nicht aktiviert",
+                            "not_configured": "Nicht konfiguriert"
                         }
                     },
                     "thursday_slot_1": {
                         "name": "Donnerstag Slot 1",
                         "state": {
-                            "not enabled": "Nicht aktiviert",
-                            "not configured": "Nicht konfiguriert"
+                            "not_enabled": "Nicht aktiviert",
+                            "not_configured": "Nicht konfiguriert"
                         }
                     },
                     "thursday_slot_2": {
                         "name": "Donnerstag Slot 2",
                         "state": {
-                            "not enabled": "Nicht aktiviert",
-                            "not configured": "Nicht konfiguriert"
+                            "not_enabled": "Nicht aktiviert",
+                            "not_configured": "Nicht konfiguriert"
                         }
                     },
                     "friday_slot_1": {
                         "name": "Freitag Slot 1",
                         "state": {
-                            "not enabled": "Nicht aktiviert",
-                            "not configured": "Nicht konfiguriert"
+                            "not_enabled": "Nicht aktiviert",
+                            "not_configured": "Nicht konfiguriert"
                         }
                     },
                     "friday_slot_2": {
                         "name": "Freitag Slot 2",
                         "state": {
-                            "not enabled": "Nicht aktiviert",
-                            "not configured": "Nicht konfiguriert"
+                            "not_enabled": "Nicht aktiviert",
+                            "not_configured": "Nicht konfiguriert"
                         }
                     },
                     "saturday_slot_1": {
                         "name": "Samstag Slot 1",
                         "state": {
-                            "not enabled": "Nicht aktiviert",
-                            "not configured": "Nicht konfiguriert"
+                            "not_enabled": "Nicht aktiviert",
+                            "not_configured": "Nicht konfiguriert"
                         }
                     },
                     "saturday_slot_2": {
                         "name": "Samstag Slot 2",
                         "state": {
-                            "not enabled": "Nicht aktiviert",
-                            "not configured": "Nicht konfiguriert"
+                            "not_enabled": "Nicht aktiviert",
+                            "not_configured": "Nicht konfiguriert"
                         }
                     },
                     "sunday_slot_1": {
                         "name": "Sonntag Slot 1",
                         "state": {
-                            "not enabled": "Nicht aktiviert",
-                            "not configured": "Nicht konfiguriert"
+                            "not_enabled": "Nicht aktiviert",
+                            "not_configured": "Nicht konfiguriert"
                         }
                     },
                     "sunday_slot_2": {
                         "name": "Sonntag Slot 2",
                         "state": {
-                            "not enabled": "Nicht aktiviert",
-                            "not configured": "Nicht konfiguriert"
+                            "not_enabled": "Nicht aktiviert",
+                            "not_configured": "Nicht konfiguriert"
                         }
                     }
                 }

--- a/custom_components/boschindego/translations/de.json
+++ b/custom_components/boschindego/translations/de.json
@@ -154,7 +154,7 @@
             "mowing_mode": {
                 "name": "Mähmodus",
                 "state": {
-                    "Calendar": "Manueller Kalender"
+                    "calendar": "Manueller Kalender"
                 }
             },
             "runtime_total": {

--- a/custom_components/boschindego/translations/de.json
+++ b/custom_components/boschindego/translations/de.json
@@ -152,7 +152,10 @@
                 "name": "Nächster Mähtermin"
             },
             "mowing_mode": {
-                "name": "Mähmodus"
+                "name": "Mähmodus",
+                "state": {
+                    "Calendar": "Manueller Kalender"
+                }
             },
             "runtime_total": {
                 "name": "Gesamtmähzeit"
@@ -195,123 +198,215 @@
             },
             "predictive_calendar_slots": {
                 "name": "SmartMowing Sperrzeiten",
+                "state": {
+                    "Manual calendar active": "Manueller Kalender aktiv",
+                    "off": "Aus"
+                },
                 "state_attributes": {
-                    "today_slot_1": {
-                        "name": "Heute Slot 1",
+                    "last_updated": {
+                        "name": "Zuletzt aktualisiert"
+                    },
+                    "smartmowing_enabled": {
+                        "name": "SmartMowing aktiv"
+                    },
+                    "mowing_mode": {
+                        "name": "Mähmodus"
+                    },
+                    "earliest_start": {
+                        "name": "Frühester Start",
                         "state": {
-                            "not enabled": "Nicht aktiviert",
-                            "not configured": "Nicht konfiguriert"
+                            "not enabled": "Nicht aktiviert"
                         }
                     },
-                    "today_slot_2": {
-                        "name": "Heute Slot 2",
+                    "latest_end": {
+                        "name": "Spätestes Ende",
                         "state": {
-                            "not enabled": "Nicht aktiviert",
-                            "not configured": "Nicht konfiguriert"
+                            "not enabled": "Nicht aktiviert"
                         }
                     },
-                    "monday_slot_1": {
-                        "name": "Montag Slot 1",
+                    "blocked_before": {
+                        "name": "Gesperrt vor",
                         "state": {
-                            "not enabled": "Nicht aktiviert",
-                            "not configured": "Nicht konfiguriert"
+                            "not enabled": "Nicht aktiviert"
                         }
                     },
-                    "monday_slot_2": {
-                        "name": "Montag Slot 2",
+                    "blocked_after": {
+                        "name": "Gesperrt nach",
                         "state": {
-                            "not enabled": "Nicht aktiviert",
-                            "not configured": "Nicht konfiguriert"
+                            "not enabled": "Nicht aktiviert"
+                        }
+                    }
+                }
+            },
+            "predictive_schedule": {
+                "name": "SmartMowing Zeitplan",
+                "state": {
+                    "Manual calendar active": "Manueller Kalender aktiv",
+                    "none": "Keine"
+                },
+                "state_attributes": {
+                    "last_updated": {
+                        "name": "Zuletzt aktualisiert"
+                    },
+                    "next_mow_slot": {
+                        "name": "Nächster geplanter Mähslot",
+                        "state": {
+                            "none": "Keine"
                         }
                     },
-                    "tuesday_slot_1": {
-                        "name": "Dienstag Slot 1",
+                    "next_mow_day": {
+                        "name": "Nächster geplanter Mähtag",
                         "state": {
-                            "not enabled": "Nicht aktiviert",
-                            "not configured": "Nicht konfiguriert"
+                            "none": "Keine",
+                            "monday": "Montag",
+                            "tuesday": "Dienstag",
+                            "wednesday": "Mittwoch",
+                            "thursday": "Donnerstag",
+                            "friday": "Freitag",
+                            "saturday": "Samstag",
+                            "sunday": "Sonntag"
                         }
                     },
-                    "tuesday_slot_2": {
-                        "name": "Dienstag Slot 2",
+                    "next_mow_time": {
+                        "name": "Nächste geplante Mähzeit",
                         "state": {
-                            "not enabled": "Nicht aktiviert",
-                            "not configured": "Nicht konfiguriert"
+                            "none": "Keine"
                         }
                     },
-                    "wednesday_slot_1": {
-                        "name": "Mittwoch Slot 1",
+                    "schedule_monday": {
+                        "name": "Zeitplan Montag",
                         "state": {
-                            "not enabled": "Nicht aktiviert",
-                            "not configured": "Nicht konfiguriert"
+                            "not scheduled": "Nicht geplant"
                         }
                     },
-                    "wednesday_slot_2": {
-                        "name": "Mittwoch Slot 2",
+                    "schedule_tuesday": {
+                        "name": "Zeitplan Dienstag",
                         "state": {
-                            "not enabled": "Nicht aktiviert",
-                            "not configured": "Nicht konfiguriert"
+                            "not scheduled": "Nicht geplant"
                         }
                     },
-                    "thursday_slot_1": {
-                        "name": "Donnerstag Slot 1",
+                    "schedule_wednesday": {
+                        "name": "Zeitplan Mittwoch",
                         "state": {
-                            "not enabled": "Nicht aktiviert",
-                            "not configured": "Nicht konfiguriert"
+                            "not scheduled": "Nicht geplant"
                         }
                     },
-                    "thursday_slot_2": {
-                        "name": "Donnerstag Slot 2",
+                    "schedule_thursday": {
+                        "name": "Zeitplan Donnerstag",
                         "state": {
-                            "not enabled": "Nicht aktiviert",
-                            "not configured": "Nicht konfiguriert"
+                            "not scheduled": "Nicht geplant"
                         }
                     },
-                    "friday_slot_1": {
-                        "name": "Freitag Slot 1",
+                    "schedule_friday": {
+                        "name": "Zeitplan Freitag",
                         "state": {
-                            "not enabled": "Nicht aktiviert",
-                            "not configured": "Nicht konfiguriert"
+                            "not scheduled": "Nicht geplant"
                         }
                     },
-                    "friday_slot_2": {
-                        "name": "Freitag Slot 2",
+                    "schedule_saturday": {
+                        "name": "Zeitplan Samstag",
                         "state": {
-                            "not enabled": "Nicht aktiviert",
-                            "not configured": "Nicht konfiguriert"
+                            "not scheduled": "Nicht geplant"
                         }
                     },
-                    "saturday_slot_1": {
-                        "name": "Samstag Slot 1",
+                    "schedule_sunday": {
+                        "name": "Zeitplan Sonntag",
                         "state": {
-                            "not enabled": "Nicht aktiviert",
-                            "not configured": "Nicht konfiguriert"
+                            "not scheduled": "Nicht geplant"
                         }
                     },
-                    "saturday_slot_2": {
-                        "name": "Samstag Slot 2",
+                    "exclusion_monday_user": {
+                        "name": "Sperrzeit Montag Benutzer",
                         "state": {
-                            "not enabled": "Nicht aktiviert",
-                            "not configured": "Nicht konfiguriert"
+                            "none": "Keine"
                         }
                     },
-                    "sunday_slot_1": {
-                        "name": "Sonntag Slot 1",
+                    "exclusion_monday_weather": {
+                        "name": "Sperrzeit Montag Wetter",
                         "state": {
-                            "not enabled": "Nicht aktiviert",
-                            "not configured": "Nicht konfiguriert"
+                            "none": "Keine"
                         }
                     },
-                    "sunday_slot_2": {
-                        "name": "Sonntag Slot 2",
+                    "exclusion_tuesday_user": {
+                        "name": "Sperrzeit Dienstag Benutzer",
                         "state": {
-                            "not enabled": "Nicht aktiviert",
-                            "not configured": "Nicht konfiguriert"
+                            "none": "Keine"
+                        }
+                    },
+                    "exclusion_tuesday_weather": {
+                        "name": "Sperrzeit Dienstag Wetter",
+                        "state": {
+                            "none": "Keine"
+                        }
+                    },
+                    "exclusion_wednesday_user": {
+                        "name": "Sperrzeit Mittwoch Benutzer",
+                        "state": {
+                            "none": "Keine"
+                        }
+                    },
+                    "exclusion_wednesday_weather": {
+                        "name": "Sperrzeit Mittwoch Wetter",
+                        "state": {
+                            "none": "Keine"
+                        }
+                    },
+                    "exclusion_thursday_user": {
+                        "name": "Sperrzeit Donnerstag Benutzer",
+                        "state": {
+                            "none": "Keine"
+                        }
+                    },
+                    "exclusion_thursday_weather": {
+                        "name": "Sperrzeit Donnerstag Wetter",
+                        "state": {
+                            "none": "Keine"
+                        }
+                    },
+                    "exclusion_friday_user": {
+                        "name": "Sperrzeit Freitag Benutzer",
+                        "state": {
+                            "none": "Keine"
+                        }
+                    },
+                    "exclusion_friday_weather": {
+                        "name": "Sperrzeit Freitag Wetter",
+                        "state": {
+                            "none": "Keine"
+                        }
+                    },
+                    "exclusion_saturday_user": {
+                        "name": "Sperrzeit Samstag Benutzer",
+                        "state": {
+                            "none": "Keine"
+                        }
+                    },
+                    "exclusion_saturday_weather": {
+                        "name": "Sperrzeit Samstag Wetter",
+                        "state": {
+                            "none": "Keine"
+                        }
+                    },
+                    "exclusion_sunday_user": {
+                        "name": "Sperrzeit Sonntag Benutzer",
+                        "state": {
+                            "none": "Keine"
+                        }
+                    },
+                    "exclusion_sunday_weather": {
+                        "name": "Sperrzeit Sonntag Wetter",
+                        "state": {
+                            "none": "Keine"
                         }
                     }
                 }
             },
             "calendar_slots": {
                 "name": "Geplante Mähzeiten",
+                "state": {
+                    "SmartMowing active": "SmartMowing aktiv",
+                    "off": "Aus"
+                },
                 "state_attributes": {
                     "today_slot_1": {
                         "name": "Heute Slot 1",

--- a/custom_components/boschindego/translations/de.json
+++ b/custom_components/boschindego/translations/de.json
@@ -199,7 +199,7 @@
             "predictive_calendar_slots": {
                 "name": "SmartMowing Sperrzeiten",
                 "state": {
-                    "Manual calendar active": "Manueller Kalender aktiv",
+                    "manual calendar active": "Manueller Kalender aktiv",
                     "off": "Aus"
                 },
                 "state_attributes": {
@@ -241,7 +241,7 @@
             "predictive_schedule": {
                 "name": "SmartMowing Zeitplan",
                 "state": {
-                    "Manual calendar active": "Manueller Kalender aktiv",
+                    "manual calendar active": "Manueller Kalender aktiv",
                     "none": "Keine"
                 },
                 "state_attributes": {
@@ -666,6 +666,24 @@
                 "end": {
                     "name": "Ende",
                     "description": "Endzeit des gewählten Slots. Wird nur benötigt wenn ein Zeitslot aktiviert werden soll. Nur Stunden und Minuten werden übernommen."
+                }
+            }
+        },
+        "set_predictive_mowing_window": {
+            "name": "Zeitfenster für SmartMowing Zeiten setzen",
+            "description": "Das Zeitfenster in dem der Mäher im SmartMowing Modus mähen darf.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Seriennummer",
+                    "description": "Seriennummer des Mähroboters. Wird nur benötigt, wenn mehrere Mähroboter eingerichtet sind."
+                },
+                "earliest_start": {
+                    "name": "Frühester Start",
+                    "description": "Um wie viel Uhr soll der Mäher frühestens beginnen."
+                },
+                "latest_end": {
+                    "name": "Spätestes Ende",
+                    "description": "Um wie viel uhr soll der Mäher spätestens beenden."
                 }
             }
         }

--- a/custom_components/boschindego/translations/en.json
+++ b/custom_components/boschindego/translations/en.json
@@ -154,7 +154,7 @@
             "mowing_mode": {
                 "name": "Mowing Mode",
                 "state": {
-                    "calendar": "Manual Calendar"
+                    "Calendar": "Manual Calendar"
                 }
             },
             "runtime_total": {

--- a/custom_components/boschindego/translations/en.json
+++ b/custom_components/boschindego/translations/en.json
@@ -129,7 +129,7 @@
                     "stuck_on_lawn_help_needed": "Stuck on lawn, help needed",
                     "returning_to_dock": "Returning to dock",
                     "returning_to_dock_battery_low": "Returning to dock - Battery low",
-                    "returning_to_dock_calendar_timeslot_ended": "Returning to Dock - Calendar timeslot ended",
+                    "returning_to_dock_calendar_timeslot_ended": "Returning to Dock -  timeslot ended",
                     "returning_to_dock_battery_temp_range": "Returning to Dock - Battery temp range",
                     "returning_to_dock_lawn_complete": "Returning to Dock - Lawn complete",
                     "returning_to_dock_relocalising": "Returning to Dock - Relocating",
@@ -154,7 +154,7 @@
             "mowing_mode": {
                 "name": "Mowing Mode",
                 "state": {
-                    "Calendar": "Manual Calendar"
+                    "calendar": "Manual Calendar"
                 }
             },
             "runtime_total": {

--- a/custom_components/boschindego/translations/en.json
+++ b/custom_components/boschindego/translations/en.json
@@ -154,7 +154,7 @@
             "mowing_mode": {
                 "name": "Mowing Mode",
                 "state": {
-                    "Calendar": "Manual Calendar"
+                    "calendar": "Manual Calendar"
                 }
             },
             "runtime_total": {

--- a/custom_components/boschindego/translations/en.json
+++ b/custom_components/boschindego/translations/en.json
@@ -129,7 +129,7 @@
                     "stuck_on_lawn_help_needed": "Stuck on lawn, help needed",
                     "returning_to_dock": "Returning to dock",
                     "returning_to_dock_battery_low": "Returning to dock - Battery low",
-                    "returning_to_dock_calendar_timeslot_ended": "Returning to Dock -  timeslot ended",
+                    "returning_to_dock_calendar_timeslot_ended": "Returning to Dock - Calendar timeslot ended",
                     "returning_to_dock_battery_temp_range": "Returning to Dock - Battery temp range",
                     "returning_to_dock_lawn_complete": "Returning to Dock - Lawn complete",
                     "returning_to_dock_relocalising": "Returning to Dock - Relocating",
@@ -198,7 +198,7 @@
             },
             "calendar_slots": {
                 "state": {
-                    "SmartMowing active": "SmartMowing active",
+                    "smartmowing_active": "SmartMowing active",
                     "off": "Off"
                 },
                 "name": "Planned mowing times",
@@ -206,113 +206,113 @@
                     "today_slot_1": {
                         "name": "Today slot 1",
                         "state": {
-                            "not enabled": "Not enabled",
-                            "not configured": "Not configured"
+                            "not_enabled": "Not enabled",
+                            "not_configured": "Not configured"
                         }
                     },
                     "today_slot_2": {
                         "name": "Today slot 2",
                         "state": {
-                            "not enabled": "Not enabled",
-                            "not configured": "Not configured"
+                            "not_enabled": "Not enabled",
+                            "not_configured": "Not configured"
                         }
                     },
                     "monday_slot_1": {
                         "name": "Monday Slot 1",
                         "state": {
-                            "not enabled": "Not enabled",
-                            "not configured": "Not configured"
+                            "not_enabled": "Not enabled",
+                            "not_configured": "Not configured"
                         }
                     },
                     "monday_slot_2": {
                         "name": "Monday Slot 2",
                         "state": {
-                            "not enabled": "Not enabled",
-                            "not configured": "Not configured"
+                            "not_enabled": "Not enabled",
+                            "not_configured": "Not configured"
                         }
                     },
                     "tuesday_slot_1": {
                         "name": "Tuesday Slot 1",
                         "state": {
-                            "not enabled": "Not enabled",
-                            "not configured": "Not configured"
+                            "not_enabled": "Not enabled",
+                            "not_configured": "Not configured"
                         }
                     },
                     "tuesday_slot_2": {
                         "name": "Tuesday Slot 2",
                         "state": {
-                            "not enabled": "Not enabled",
-                            "not configured": "Not configured"
+                            "not_enabled": "Not enabled",
+                            "not_configured": "Not configured"
                         }
                     },
                     "wednesday_slot_1": {
                         "name": "Wednesday Slot 1",
                         "state": {
-                            "not enabled": "Not enabled",
-                            "not configured": "Not configured"
+                            "not_enabled": "Not enabled",
+                            "not_configured": "Not configured"
                         }
                     },
                     "wednesday_slot_2": {
                         "name": "Wednesday Slot 2",
                         "state": {
-                            "not enabled": "Not enabled",
-                            "not configured": "Not configured"
+                            "not_enabled": "Not enabled",
+                            "not_configured": "Not configured"
                         }
                     },
                     "thursday_slot_1": {
                         "name": "Thursday Slot 1",
                         "state": {
-                            "not enabled": "Not enabled",
-                            "not configured": "Not configured"
+                            "not_enabled": "Not enabled",
+                            "not_configured": "Not configured"
                         }
                     },
                     "thursday_slot_2": {
                         "name": "Thursday Slot 2",
                         "state": {
-                            "not enabled": "Not enabled",
-                            "not configured": "Not configured"
+                            "not_enabled": "Not enabled",
+                            "not_configured": "Not configured"
                         }
                     },
                     "friday_slot_1": {
                         "name": "Friday Slot 1",
                         "state": {
-                            "not enabled": "Not enabled",
-                            "not configured": "Not configured"
+                            "not_enabled": "Not enabled",
+                            "not_configured": "Not configured"
                         }
                     },
                     "friday_slot_2": {
                         "name": "Friday Slot 2",
                         "state": {
-                            "not enabled": "Not enabled",
-                            "not configured": "Not configured"
+                            "not_enabled": "Not enabled",
+                            "not_configured": "Not configured"
                         }
                     },
                     "saturday_slot_1": {
                         "name": "Saturday Slot 1",
                         "state": {
-                            "not enabled": "Not enabled",
-                            "not configured": "Not configured"
+                            "not_enabled": "Not enabled",
+                            "not_configured": "Not configured"
                         }
                     },
                     "saturday_slot_2": {
                         "name": "Saturday Slot 2",
                         "state": {
-                            "not enabled": "Not enabled",
-                            "not configured": "Not configured"
+                            "not_enabled": "Not enabled",
+                            "not_configured": "Not configured"
                         }
                     },
                     "sunday_slot_1": {
                         "name": "Sunday Slot 1",
                         "state": {
-                            "not enabled": "Not enabled",
-                            "not configured": "Not configured"
+                            "not_enabled": "Not enabled",
+                            "not_configured": "Not configured"
                         }
                     },
                     "sunday_slot_2": {
                         "name": "Sunday Slot 2",
                         "state": {
-                            "not enabled": "Not enabled",
-                            "not configured": "Not configured"
+                            "not_enabled": "Not enabled",
+                            "not_configured": "Not configured"
                         }
                     }
                 }
@@ -320,7 +320,7 @@
             "predictive_calendar_slots": {
                 "name": "SmartMowing blocked times",
                 "state": {
-                    "manual calendar active": "Manual calendar active",
+                    "manual_calendar_active": "Manual calendar active",
                     "off": "Off"
                 },
                 "state_attributes": {
@@ -336,25 +336,25 @@
                     "earliest_start": {
                         "name": "Earliest start",
                         "state": {
-                            "not enabled": "Not enabled"
+                            "not_enabled": "Not enabled"
                         }
                     },
                     "latest_end": {
                         "name": "Latest end",
                         "state": {
-                            "not enabled": "Not enabled"
+                            "not_enabled": "Not enabled"
                         }
                     },
                     "blocked_before": {
                         "name": "Blocked before",
                         "state": {
-                            "not enabled": "Not enabled"
+                            "not_enabled": "Not enabled"
                         }
                     },
                     "blocked_after": {
                         "name": "Blocked after",
                         "state": {
-                            "not enabled": "Not enabled"
+                            "not_enabled": "Not enabled"
                         }
                     }
                 }
@@ -362,7 +362,7 @@
             "predictive_schedule": {
                 "name": "SmartMowing schedule",
                 "state": {
-                    "manual calendar active": "Manual calendar active",
+                    "manual_calendar_active": "Manual calendar active",
                     "none": "None"
                 },
                 "state_attributes": {
@@ -397,7 +397,7 @@
                     "schedule_monday": {
                         "name": "Schedule Monday",
                         "state": {
-                            "not scheduled": "Not scheduled"
+                            "not_scheduled": "Not scheduled"
                         }
                     },
                     "exclusion_monday_user": {
@@ -415,7 +415,7 @@
                     "schedule_tuesday": {
                         "name": "Schedule Tuesday",
                         "state": {
-                            "not scheduled": "Not scheduled"
+                            "not_scheduled": "Not scheduled"
                         }
                     },
                     "exclusion_tuesday_user": {
@@ -433,7 +433,7 @@
                     "schedule_wednesday": {
                         "name": "Schedule Wednesday",
                         "state": {
-                            "not scheduled": "Not scheduled"
+                            "not_scheduled": "Not scheduled"
                         }
                     },
                     "exclusion_wednesday_user": {
@@ -451,7 +451,7 @@
                     "schedule_thursday": {
                         "name": "Schedule Thursday",
                         "state": {
-                            "not scheduled": "Not scheduled"
+                            "not_scheduled": "Not scheduled"
                         }
                     },
                     "exclusion_thursday_user": {
@@ -469,7 +469,7 @@
                     "schedule_friday": {
                         "name": "Schedule Friday",
                         "state": {
-                            "not scheduled": "Not scheduled"
+                            "not_scheduled": "Not scheduled"
                         }
                     },
                     "exclusion_friday_user": {
@@ -487,7 +487,7 @@
                     "schedule_saturday": {
                         "name": "Schedule Saturday",
                         "state": {
-                            "not scheduled": "Not scheduled"
+                            "not_scheduled": "Not scheduled"
                         }
                     },
                     "exclusion_saturday_user": {
@@ -505,7 +505,7 @@
                     "schedule_sunday": {
                         "name": "Schedule Sunday",
                         "state": {
-                            "not scheduled": "Not scheduled"
+                            "not_scheduled": "Not scheduled"
                         }
                     },
                     "exclusion_sunday_user": {

--- a/custom_components/boschindego/translations/en.json
+++ b/custom_components/boschindego/translations/en.json
@@ -1,381 +1,710 @@
 {
-  "config": {
-    "abort": {
-      "already_configured": "This Bosch Indego mower has already been configured!",
-      "connection_error": "The connection to the Bosch Indego API failed! Please check the documentation for known issues and possible solutions.",
-      "no_mowers_found": "No mowers found in this Bosch Indego account!",
-      "reauth_successful": "Re-authentication was successful. Access to the Bosch API has been restored."
-    },
-    "step": {
-      "advanced": {
-        "data": {
-          "user_agent": "User-Agent",
-          "expose_mower": "Expose Indego mower as mower entity in Home Assistant",
-          "expose_vacuum": "Expose Indego mower as vacuum entity in Home Assistant"
+    "config": {
+        "abort": {
+            "already_configured": "This Bosch Indego mower has already been configured!",
+            "connection_error": "The connection to the Bosch Indego API failed! Please check the documentation for known issues and possible solutions.",
+            "no_mowers_found": "No mowers found in this Bosch Indego account!",
+            "reauth_successful": "Re-authentication was successful. Access to the Bosch API has been restored."
         },
-        "data_description": {
-          "user_agent": "In case of HTTP 4XX errors (especially Reason: 403, message='Forbidden') it might help to change the User Agent. Should not contain Homeassistant or HA."
-        },
-        "description": "Advanced settings of the Bosch Indego component."
-      },
-      "mower": {
-        "data": {
-          "mower_serial": "Mower serial",
-          "mower_name": "Mower name"
-        },
-        "description": "Please select the serial of the Bosch Mower you would like to add."
-      },
-      "reauth_confirm": {
-        "title": "Authentication expired",
-        "description": "The Bosch Indego API authentication has expired. Please re-authenticate using your Bosch SingleKey ID."
-      }
-    }
-  },
-  "options": {
-    "step": {
-      "init": {
-        "title": "Advanced settings",
-        "description": "Advanced settings of the Bosch Indego component. You might have to reload the component after changing these settings.",
-        "data": {
-          "user_agent": "User-Agent",
-          "expose_mower": "Expose Indego mower as mower entity in Home Assistant",
-          "expose_vacuum": "Expose Indego mower as vacuum entity in Home Assistant",
-          "show_all_alerts": "Show the full alert history in Home Assistant. This is not recommended for most users, as it might have a significant impact on the Home Assistant database size!"
-        },
-        "data_description": {
-          "user_agent": "Custom User-Agent header for API requests to Bosch Indego Cloud. Leave empty to use default. Some users may need to set a custom value if their account has API access restrictions."
-        }
-      }
-    }
-  },
-  "entity": {
-    "binary_sensor": {
-      "indego_alert": {
-        "state_attributes": {
-          "alerts_count": {
-            "name": "Number of alerts"
-          },
-          "last_alert_error_code": {
-            "name": "Error code (most recent)"
-          },
-          "last_alert_message": {
-            "name": "Alert message (most recent)"
-          },
-          "last_alert_date": {
-            "name": "Alert date (most recent)"
-          },
-          "last_alert_read": {
-            "name": "Alert status (most recent)",
-            "state": {
-              "read": "Read",
-              "unread": "Unread"
+        "step": {
+            "advanced": {
+                "data": {
+                    "user_agent": "User-Agent",
+                    "expose_mower": "Expose Indego mower as mower entity in Home Assistant",
+                    "expose_vacuum": "Expose Indego mower as vacuum entity in Home Assistant"
+                },
+                "data_description": {
+                    "user_agent": "In case of HTTP 4XX errors (especially Reason: 403, message='Forbidden') it might help to change the User Agent. Should not contain Homeassistant or HA."
+                },
+                "description": "Advanced settings of the Bosch Indego component."
+            },
+            "mower": {
+                "data": {
+                    "mower_serial": "Mower serial",
+                    "mower_name": "Mower name"
+                },
+                "description": "Please select the serial of the Bosch Mower you would like to add."
+            },
+            "reauth_confirm": {
+                "title": "Authentication expired",
+                "description": "The Bosch Indego API authentication has expired. Please re-authenticate using your Bosch SingleKey ID."
             }
-          }
         }
-      },
-      "online": {
-        "name": "Online"
-      },
-      "update_available": {
-        "name": "Update Available"
-      },
-      "mower_stuck": {
-        "name": "Mower Stuck"
-      },
-      "service_status": {
-        "name": "Service Status"
-      },
-      "battery_charging": {
-        "name": "Charge Status"
-      }
     },
-    "sensor": {
-      "mower_state": {
-        "name": "Mower State",
-        "state": {
-          "mowing": "Mowing",
-          "docked": "Docked",
-          "sleeping": "Sleeping",
-          "paused": "Paused"
+    "options": {
+        "step": {
+            "init": {
+                "title": "Advanced settings",
+                "description": "Advanced settings of the Bosch Indego component. You might have to reload the component after changing these settings.",
+                "data": {
+                    "user_agent": "User-Agent",
+                    "expose_mower": "Expose Indego mower as mower entity in Home Assistant",
+                    "expose_vacuum": "Expose Indego mower as vacuum entity in Home Assistant",
+                    "show_all_alerts": "Show the full alert history in Home Assistant. This is not recommended for most users, as it might have a significant impact on the Home Assistant database size!"
+                },
+                "data_description": {
+                    "user_agent": "Custom User-Agent header for API requests to Bosch Indego Cloud. Leave empty to use default. Some users may need to set a custom value if their account has API access restrictions."
+                }
+            }
         }
-      },
-      "mower_state_detail": {
-        "name": "Mower State Detail",
-        "state": {
-          "reading_status": "Reading status",
-          "charging": "Charging",
-          "docked": "Docked",
-          "sleeping": "Sleeping",
-          "docked_software_update": "Docked - Software update",
-          "docked_loading_map": "Docked - Loading map",
-          "docked_saving_map": "Docked - Saving map",
-          "docked_leaving_dock": "Docked - Leaving dock",
-          "mowing": "Mowing",
-          "mowing_relocalising": "Mowing - Relocating",
-          "mowing_learning_lawn": "Mowing - Learning Lawn",
-          "mowing_learning_lawn_paused": "Mowing - Learning Lawn paused",
-          "spotmow": "SpotMow",
-          "mowing_randomly": "Mowing randomly",
-          "diagnostic_mode": "Diagnostic mode",
-          "end_of_life": "End of life",
-          "software_update": "Software update",
-          "energy_save_mode": "Energy save mode",
-          "relocalising": "Relocating",
-          "loading_map": "Loading map",
-          "learning_lawn": "Learning lawn",
-          "paused": "Paused",
-          "border_cut": "Border cut",
-          "idle_in_lawn": "Idle in lawn",
-          "stuck_on_lawn_help_needed": "Stuck on lawn, help needed",
-          "returning_to_dock": "Returning to dock",
-          "returning_to_dock_battery_low": "Returning to dock - Battery low",
-          "returning_to_dock_calendar_timeslot_ended": "Returning to Dock - Calendar timeslot ended",
-          "returning_to_dock_battery_temp_range": "Returning to Dock - Battery temp range",
-          "returning_to_dock_lawn_complete": "Returning to Dock - Lawn complete",
-          "returning_to_dock_relocalising": "Returning to Dock - Relocating",
-          "returning_to_dock_requested_by_user_app": "Returning to Dock - requested by user/app"
-        }
-      },
-      "battery_percentage": {
-        "name": "Battery"
-      },
-      "lawn_mowed": {
-        "name": "Lawn Mowed"
-      },
-      "lawn_mowed_size": {
-        "name": "Lawn Mowed Size"
-      },
-      "last_completed": {
-        "name": "Last Completed"
-      },
-      "next_mow": {
-        "name": "Next Mow"
-      },
-      "mowing_mode": {
-        "name": "Mowing Mode"
-      },
-      "runtime_total": {
-        "name": "Mow Time Total"
-      },
-      "garden_size": {
-        "name": "Garden Size"
-      },
-      "mower_position_x": {
-        "name": "Mower Position X"
-      },
-      "mower_position_y": {
-        "name": "Mower Position Y"
-      },
-      "last_error_code": {
-        "name": "Last Error"
-      },
-      "firmware_version": {
-        "name": "Firmware Version"
-      },
-      "maintenance_hours": {
-        "name": "Maintenance Hours"
-      },
-      "session_count": {
-        "name": "Session Count"
-      },
-      "battery_voltage": {
-        "name": "Battery Voltage"
-      },
-      "battery_temperature": {
-        "name": "Battery Temperature"
-      },
-      "ambient_temperature": {
-        "name": "Ambient Temperature"
-      },
-      "battery_cycles": {
-        "name": "Battery Cycles"
-      },
-      "battery_discharge": {
-        "name": "Battery Discharge"
-      }
     },
-    "camera": {
-      "mowing_map": {
-        "name": "Mowing Map"
-      }
-    },
-    "button": {
-      "delete_all_alerts": {
-        "name": "Delete All Alerts"
-      },
-      "delete_last_alert": {
-        "name": "Delete Last Alert"
-      },
-      "read_all_alerts": {
-        "name": "Mark All Alerts as Read"
-      },
-      "read_last_alert": {
-        "name": "Mark Last Alert as Read"
-      }
-    },
-    "switch": {
-      "indego_smartmowing": {
-        "name": "SmartMowing"
-      }
-    }
-  },
-  "services": {
-    "command": {
-      "name": "Send command",
-      "description": "Send commands to the mower. Allowed commands are mow, returnToDock, and pause.",
-      "fields": {
-        "mower_serial": {
-          "name": "Mower Serial",
-          "description": "Mower serial. Only needed when you have configured multiple mowers."
+    "entity": {
+        "binary_sensor": {
+            "indego_alert": {
+                "state_attributes": {
+                    "alerts_count": {
+                        "name": "Number of alerts"
+                    },
+                    "last_alert_error_code": {
+                        "name": "Error code (most recent)"
+                    },
+                    "last_alert_message": {
+                        "name": "Alert message (most recent)"
+                    },
+                    "last_alert_date": {
+                        "name": "Alert date (most recent)"
+                    },
+                    "last_alert_read": {
+                        "name": "Alert status (most recent)",
+                        "state": {
+                            "read": "Read",
+                            "unread": "Unread"
+                        }
+                    }
+                }
+            },
+            "online": {
+                "name": "Online"
+            },
+            "update_available": {
+                "name": "Update Available"
+            },
+            "mower_stuck": {
+                "name": "Mower Stuck"
+            },
+            "service_status": {
+                "name": "Service Status"
+            },
+            "battery_charging": {
+                "name": "Charge Status"
+            }
         },
+        "sensor": {
+            "mower_state": {
+                "name": "Mower State",
+                "state": {
+                    "mowing": "Mowing",
+                    "docked": "Docked",
+                    "sleeping": "Sleeping",
+                    "paused": "Paused"
+                }
+            },
+            "mower_state_detail": {
+                "name": "Mower State Detail",
+                "state": {
+                    "reading_status": "Reading status",
+                    "charging": "Charging",
+                    "docked": "Docked",
+                    "sleeping": "Sleeping",
+                    "docked_software_update": "Docked - Software update",
+                    "docked_loading_map": "Docked - Loading map",
+                    "docked_saving_map": "Docked - Saving map",
+                    "docked_leaving_dock": "Docked - Leaving dock",
+                    "mowing": "Mowing",
+                    "mowing_relocalising": "Mowing - Relocating",
+                    "mowing_learning_lawn": "Mowing - Learning Lawn",
+                    "mowing_learning_lawn_paused": "Mowing - Learning Lawn paused",
+                    "spotmow": "SpotMow",
+                    "mowing_randomly": "Mowing randomly",
+                    "diagnostic_mode": "Diagnostic mode",
+                    "end_of_life": "End of life",
+                    "software_update": "Software update",
+                    "energy_save_mode": "Energy save mode",
+                    "relocalising": "Relocating",
+                    "loading_map": "Loading map",
+                    "learning_lawn": "Learning lawn",
+                    "paused": "Paused",
+                    "border_cut": "Border cut",
+                    "idle_in_lawn": "Idle in lawn",
+                    "stuck_on_lawn_help_needed": "Stuck on lawn, help needed",
+                    "returning_to_dock": "Returning to dock",
+                    "returning_to_dock_battery_low": "Returning to dock - Battery low",
+                    "returning_to_dock_calendar_timeslot_ended": "Returning to Dock - Calendar timeslot ended",
+                    "returning_to_dock_battery_temp_range": "Returning to Dock - Battery temp range",
+                    "returning_to_dock_lawn_complete": "Returning to Dock - Lawn complete",
+                    "returning_to_dock_relocalising": "Returning to Dock - Relocating",
+                    "returning_to_dock_requested_by_user_app": "Returning to Dock - requested by user/app"
+                }
+            },
+            "battery_percentage": {
+                "name": "Battery"
+            },
+            "lawn_mowed": {
+                "name": "Lawn Mowed"
+            },
+            "lawn_mowed_size": {
+                "name": "Lawn Mowed Size"
+            },
+            "last_completed": {
+                "name": "Last Completed"
+            },
+            "next_mow": {
+                "name": "Next Mow"
+            },
+            "mowing_mode": {
+                "name": "Mowing Mode",
+                "state": {
+                    "Calendar": "Manual Calendar"
+                }
+            },
+            "runtime_total": {
+                "name": "Mow Time Total"
+            },
+            "garden_size": {
+                "name": "Garden Size"
+            },
+            "mower_position_x": {
+                "name": "Mower Position X"
+            },
+            "mower_position_y": {
+                "name": "Mower Position Y"
+            },
+            "last_error_code": {
+                "name": "Last Error"
+            },
+            "firmware_version": {
+                "name": "Firmware Version"
+            },
+            "maintenance_hours": {
+                "name": "Maintenance Hours"
+            },
+            "session_count": {
+                "name": "Session Count"
+            },
+            "battery_voltage": {
+                "name": "Battery Voltage"
+            },
+            "battery_temperature": {
+                "name": "Battery Temperature"
+            },
+            "ambient_temperature": {
+                "name": "Ambient Temperature"
+            },
+            "battery_cycles": {
+                "name": "Battery Cycles"
+            },
+            "battery_discharge": {
+                "name": "Battery Discharge"
+            },
+            "calendar_slots": {
+                "state": {
+                    "SmartMowing active": "SmartMowing active",
+                    "off": "Off"
+                },
+                "name": "Planned mowing times",
+                "state_attributes": {
+                    "today_slot_1": {
+                        "name": "Today slot 1",
+                        "state": {
+                            "not enabled": "Not enabled",
+                            "not configured": "Not configured"
+                        }
+                    },
+                    "today_slot_2": {
+                        "name": "Today slot 2",
+                        "state": {
+                            "not enabled": "Not enabled",
+                            "not configured": "Not configured"
+                        }
+                    },
+                    "monday_slot_1": {
+                        "name": "Monday Slot 1",
+                        "state": {
+                            "not enabled": "Not enabled",
+                            "not configured": "Not configured"
+                        }
+                    },
+                    "monday_slot_2": {
+                        "name": "Monday Slot 2",
+                        "state": {
+                            "not enabled": "Not enabled",
+                            "not configured": "Not configured"
+                        }
+                    },
+                    "tuesday_slot_1": {
+                        "name": "Tuesday Slot 1",
+                        "state": {
+                            "not enabled": "Not enabled",
+                            "not configured": "Not configured"
+                        }
+                    },
+                    "tuesday_slot_2": {
+                        "name": "Tuesday Slot 2",
+                        "state": {
+                            "not enabled": "Not enabled",
+                            "not configured": "Not configured"
+                        }
+                    },
+                    "wednesday_slot_1": {
+                        "name": "Wednesday Slot 1",
+                        "state": {
+                            "not enabled": "Not enabled",
+                            "not configured": "Not configured"
+                        }
+                    },
+                    "wednesday_slot_2": {
+                        "name": "Wednesday Slot 2",
+                        "state": {
+                            "not enabled": "Not enabled",
+                            "not configured": "Not configured"
+                        }
+                    },
+                    "thursday_slot_1": {
+                        "name": "Thursday Slot 1",
+                        "state": {
+                            "not enabled": "Not enabled",
+                            "not configured": "Not configured"
+                        }
+                    },
+                    "thursday_slot_2": {
+                        "name": "Thursday Slot 2",
+                        "state": {
+                            "not enabled": "Not enabled",
+                            "not configured": "Not configured"
+                        }
+                    },
+                    "friday_slot_1": {
+                        "name": "Friday Slot 1",
+                        "state": {
+                            "not enabled": "Not enabled",
+                            "not configured": "Not configured"
+                        }
+                    },
+                    "friday_slot_2": {
+                        "name": "Friday Slot 2",
+                        "state": {
+                            "not enabled": "Not enabled",
+                            "not configured": "Not configured"
+                        }
+                    },
+                    "saturday_slot_1": {
+                        "name": "Saturday Slot 1",
+                        "state": {
+                            "not enabled": "Not enabled",
+                            "not configured": "Not configured"
+                        }
+                    },
+                    "saturday_slot_2": {
+                        "name": "Saturday Slot 2",
+                        "state": {
+                            "not enabled": "Not enabled",
+                            "not configured": "Not configured"
+                        }
+                    },
+                    "sunday_slot_1": {
+                        "name": "Sunday Slot 1",
+                        "state": {
+                            "not enabled": "Not enabled",
+                            "not configured": "Not configured"
+                        }
+                    },
+                    "sunday_slot_2": {
+                        "name": "Sunday Slot 2",
+                        "state": {
+                            "not enabled": "Not enabled",
+                            "not configured": "Not configured"
+                        }
+                    }
+                }
+            },
+            "predictive_calendar_slots": {
+                "name": "SmartMowing blocked times",
+                "state": {
+                    "Manual calendar active": "Manual calendar active",
+                    "off": "Off"
+                },
+                "state_attributes": {
+                    "last_updated": {
+                        "name": "Last updated"
+                    },
+                    "smartmowing_enabled": {
+                        "name": "SmartMowing active"
+                    },
+                    "mowing_mode": {
+                        "name": "Mowing mode"
+                    },
+                    "earliest_start": {
+                        "name": "Earliest start",
+                        "state": {
+                            "not enabled": "Not enabled"
+                        }
+                    },
+                    "latest_end": {
+                        "name": "Latest end",
+                        "state": {
+                            "not enabled": "Not enabled"
+                        }
+                    },
+                    "blocked_before": {
+                        "name": "Blocked before",
+                        "state": {
+                            "not enabled": "Not enabled"
+                        }
+                    },
+                    "blocked_after": {
+                        "name": "Blocked after",
+                        "state": {
+                            "not enabled": "Not enabled"
+                        }
+                    }
+                }
+            },
+            "predictive_schedule": {
+                "name": "SmartMowing schedule",
+                "state": {
+                    "Manual calendar active": "Manual calendar active",
+                    "none": "None"
+                },
+                "state_attributes": {
+                    "last_updated": {
+                        "name": "Last updated"
+                    },
+                    "next_mow_slot": {
+                        "name": "Next planned mowing slot",
+                        "state": {
+                            "none": "None"
+                        }
+                    },
+                    "next_mow_day": {
+                        "name": "Next planned mowing day",
+                        "state": {
+                            "none": "None",
+                            "monday": "Monday",
+                            "tuesday": "Tuesday",
+                            "wednesday": "Wednesday",
+                            "thursday": "Thursday",
+                            "friday": "Friday",
+                            "saturday": "Saturday",
+                            "sunday": "Sunday"
+                        }
+                    },
+                    "next_mow_time": {
+                        "name": "Next planned mowing time",
+                        "state": {
+                            "none": "None"
+                        }
+                    },
+                    "schedule_monday": {
+                        "name": "Schedule Monday",
+                        "state": {
+                            "not scheduled": "Not scheduled"
+                        }
+                    },
+                    "exclusion_monday_user": {
+                        "name": "Blocked time Monday user",
+                        "state": {
+                            "none": "None"
+                        }
+                    },
+                    "exclusion_monday_weather": {
+                        "name": "Blocked time Monday weather",
+                        "state": {
+                            "none": "None"
+                        }
+                    },
+                    "schedule_tuesday": {
+                        "name": "Schedule Tuesday",
+                        "state": {
+                            "not scheduled": "Not scheduled"
+                        }
+                    },
+                    "exclusion_tuesday_user": {
+                        "name": "Blocked time Tuesday user",
+                        "state": {
+                            "none": "None"
+                        }
+                    },
+                    "exclusion_tuesday_weather": {
+                        "name": "Blocked time Tuesday weather",
+                        "state": {
+                            "none": "None"
+                        }
+                    },
+                    "schedule_wednesday": {
+                        "name": "Schedule Wednesday",
+                        "state": {
+                            "not scheduled": "Not scheduled"
+                        }
+                    },
+                    "exclusion_wednesday_user": {
+                        "name": "Blocked time Wednesday user",
+                        "state": {
+                            "none": "None"
+                        }
+                    },
+                    "exclusion_wednesday_weather": {
+                        "name": "Blocked time Wednesday weather",
+                        "state": {
+                            "none": "None"
+                        }
+                    },
+                    "schedule_thursday": {
+                        "name": "Schedule Thursday",
+                        "state": {
+                            "not scheduled": "Not scheduled"
+                        }
+                    },
+                    "exclusion_thursday_user": {
+                        "name": "Blocked time Thursday user",
+                        "state": {
+                            "none": "None"
+                        }
+                    },
+                    "exclusion_thursday_weather": {
+                        "name": "Blocked time Thursday weather",
+                        "state": {
+                            "none": "None"
+                        }
+                    },
+                    "schedule_friday": {
+                        "name": "Schedule Friday",
+                        "state": {
+                            "not scheduled": "Not scheduled"
+                        }
+                    },
+                    "exclusion_friday_user": {
+                        "name": "Blocked time Friday user",
+                        "state": {
+                            "none": "None"
+                        }
+                    },
+                    "exclusion_friday_weather": {
+                        "name": "Blocked time Friday weather",
+                        "state": {
+                            "none": "None"
+                        }
+                    },
+                    "schedule_saturday": {
+                        "name": "Schedule Saturday",
+                        "state": {
+                            "not scheduled": "Not scheduled"
+                        }
+                    },
+                    "exclusion_saturday_user": {
+                        "name": "Blocked time Saturday user",
+                        "state": {
+                            "none": "None"
+                        }
+                    },
+                    "exclusion_saturday_weather": {
+                        "name": "Blocked time Saturday weather",
+                        "state": {
+                            "none": "None"
+                        }
+                    },
+                    "schedule_sunday": {
+                        "name": "Schedule Sunday",
+                        "state": {
+                            "not scheduled": "Not scheduled"
+                        }
+                    },
+                    "exclusion_sunday_user": {
+                        "name": "Blocked time Sunday user",
+                        "state": {
+                            "none": "None"
+                        }
+                    },
+                    "exclusion_sunday_weather": {
+                        "name": "Blocked time Sunday weather",
+                        "state": {
+                            "none": "None"
+                        }
+                    }
+                }
+            }
+        },
+        "camera": {
+            "mowing_map": {
+                "name": "Mowing Map"
+            }
+        },
+        "button": {
+            "delete_all_alerts": {
+                "name": "Delete All Alerts"
+            },
+            "delete_last_alert": {
+                "name": "Delete Last Alert"
+            },
+            "read_all_alerts": {
+                "name": "Mark All Alerts as Read"
+            },
+            "read_last_alert": {
+                "name": "Mark Last Alert as Read"
+            }
+        },
+        "switch": {
+            "indego_smartmowing": {
+                "name": "SmartMowing"
+            }
+        }
+    },
+    "services": {
         "command": {
-          "name": "Command",
-          "description": "Select a command to send to the mower."
+            "name": "Send command",
+            "description": "Send commands to the mower. Allowed commands are mow, returnToDock, and pause.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Mower Serial",
+                    "description": "Mower serial. Only needed when you have configured multiple mowers."
+                },
+                "command": {
+                    "name": "Command",
+                    "description": "Select a command to send to the mower."
+                }
+            }
+        },
+        "smartmowing": {
+            "name": "Toggle SmartMowing",
+            "description": "Enable or disable SmartMowing. Allowed values are true or false.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Mower Serial",
+                    "description": "Mower serial. Only needed when you have configured multiple mowers."
+                },
+                "enable": {
+                    "name": "Enable",
+                    "description": "Enable SmartMowing."
+                }
+            }
+        },
+        "delete_alert": {
+            "name": "Delete alert",
+            "description": "Delete the selected alert.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Mower Serial",
+                    "description": "Mower serial. Only needed when you have configured multiple mowers."
+                },
+                "alert_index": {
+                    "name": "Alert Index",
+                    "description": "Delete the selected alert. 0 for the latest alert."
+                }
+            }
+        },
+        "delete_alert_all": {
+            "name": "Delete all alerts",
+            "description": "Delete all alerts.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Mower Serial",
+                    "description": "Mower serial. Only needed when you have configured multiple mowers."
+                }
+            }
+        },
+        "read_alert": {
+            "name": "Mark alert as read",
+            "description": "Mark the selected alert as read.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Mower Serial",
+                    "description": "Mower serial. Only needed when you have configured multiple mowers."
+                },
+                "alert_index": {
+                    "name": "Alert Index",
+                    "description": "Mark the selected alert as read. 0 for the latest alert."
+                }
+            }
+        },
+        "read_alert_all": {
+            "name": "Mark all alerts as read",
+            "description": "Mark all alerts as read.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Mower Serial",
+                    "description": "Mower serial. Only needed when you have configured multiple mowers."
+                }
+            }
+        },
+        "download_map": {
+            "name": "Download mowing map",
+            "description": "Downloads the current mowing map from the Bosch Cloud API and saves it locally as \"www/indego_map_base.svg\". The map reflects the most recently recorded mowing route.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Mower Serial",
+                    "description": "Mower serial. Only needed when you have configured multiple mowers."
+                }
+            }
+        },
+        "set_calendar_slot": {
+            "name": "Activate/Deactivate calendar slot",
+            "description": "Set a calender slot when you use the manual calendar instead of SmartMowing.",
+            "fields": {
+                "mower_serial": {
+                    "name": "Serialnumber",
+                    "description": "Serial number of the mower. Only required if multiple mowers are configured."
+                },
+                "calendar_type": {
+                    "name": "Calendar Type",
+                    "description": "Type of calendar to use. Use 'calendar' for manual calendar or 'predictive' for the forbidden time slots in SmartMowing mode."
+                },
+                "day": {
+                    "name": "Day",
+                    "description": "Which day to configure.",
+                    "example": "Montag"
+                },
+                "slot": {
+                    "name": "Time slot",
+                    "description": "Which Slot of the selected day should be configured (1 or 2)."
+                },
+                "enabled": {
+                    "name": "Activate/Deactivate",
+                    "description": "Should the selected slot be enabled or disabled."
+                },
+                "start": {
+                    "name": "Start",
+                    "description": "Set Start Time of the selected slot and day. Only needed if you want to enable a slot."
+                },
+                "end": {
+                    "name": "End",
+                    "description": "Set End Time of the selected slot and day. Only needed if you want to enable a slot."
+                }
+            }
         }
-      }
     },
-    "smartmowing": {
-      "name": "Toggle SmartMowing",
-      "description": "Enable or disable SmartMowing. Allowed values are true or false.",
-      "fields": {
-        "mower_serial": {
-          "name": "Mower Serial",
-          "description": "Mower serial. Only needed when you have configured multiple mowers."
+    "selector": {
+        "calendar_type_options": {
+            "options": {
+                "calendar": "Manual Calendar",
+                "predictive": "SmartMowing predicted slots"
+            }
         },
-        "enable": {
-          "name": "Enable",
-          "description": "Enable SmartMowing."
+        "day_options": {
+            "options": {
+                "monday": "Monday",
+                "tuesday": "Tuesday",
+                "wednesday": "Wednesday",
+                "thursday": "Thursday",
+                "friday": "Friday",
+                "saturday": "Saturday",
+                "sunday": "Sunday"
+            }
+        },
+        "command_options": {
+            "options": {
+                "mow": "Mow",
+                "return_to_dock": "Return to dock",
+                "pause": "Pause"
+            }
         }
-      }
     },
-    "delete_alert": {
-      "name": "Delete alert",
-      "description": "Delete the selected alert.",
-      "fields": {
-        "mower_serial": {
-          "name": "Mower Serial",
-          "description": "Mower serial. Only needed when you have configured multiple mowers."
+    "issues": {
+        "auth_failure": {
+            "title": "Bosch Indego authentication expired",
+            "description": "Your authentication with Bosch Indego has expired. Please go to Settings > Devices & Services > Indego > Re-authenticate to restore access to your mower."
         },
-        "alert_index": {
-          "name": "Alert Index",
-          "description": "Delete the selected alert. 0 for the latest alert."
+        "connection_failure": {
+            "title": "Bosch Indego connection problems",
+            "description": "Your mower has not responded to API requests for an extended period. This may indicate network issues, the Bosch service is experiencing problems, or your mower is offline. Please check your internet connection and mower status."
         }
-      }
-    },
-    "delete_alert_all": {
-      "name": "Delete all alerts",
-      "description": "Delete all alerts.",
-      "fields": {
-        "mower_serial": {
-          "name": "Mower Serial",
-          "description": "Mower serial. Only needed when you have configured multiple mowers."
-        }
-      }
-    },
-    "read_alert": {
-      "name": "Mark alert as read",
-      "description": "Mark the selected alert as read.",
-      "fields": {
-        "mower_serial": {
-          "name": "Mower Serial",
-          "description": "Mower serial. Only needed when you have configured multiple mowers."
-        },
-        "alert_index": {
-          "name": "Alert Index",
-          "description": "Mark the selected alert as read. 0 for the latest alert."
-        }
-      }
-    },
-    "read_alert_all": {
-      "name": "Mark all alerts as read",
-      "description": "Mark all alerts as read.",
-      "fields": {
-        "mower_serial": {
-          "name": "Mower Serial",
-          "description": "Mower serial. Only needed when you have configured multiple mowers."
-        }
-      }
-    },
-    "download_map": {
-      "name": "Download mowing map",
-      "description": "Downloads the current mowing map from the Bosch Cloud API and saves it locally as \"www/indego_map_base.svg\". The map reflects the most recently recorded mowing route.",
-      "fields": {
-        "mower_serial": {
-          "name": "Mower Serial",
-          "description": "Mower serial. Only needed when you have configured multiple mowers."
-        }
-      }
-    },
-    "set_calendar_slot": {
-      "name": "Activate/Deactivate calendar slot",
-      "description": "Set a calender slot when you use the manual calendar instead of SmartMowing.",
-      "fields": {
-        "mower_serial": {
-          "name": "Serialnumber",
-          "description": "Serial number of the mower. Only required if multiple mowers are configured."
-        },
-        "calendar_type": {
-          "name": "Calendar Type",
-          "description": "Type of calendar to use. Use 'calendar' for manual calendar or 'predictive' for the forbidden time slots in SmartMowing mode."
-        },
-        "day": {
-          "name": "Day",
-          "description": "Which day to configure.",
-          "example": "Montag"
-        },
-        "slot": {
-          "name": "Time slot",
-          "description": "Which Slot of the selected day should be configured (1 or 2)."
-        },
-        "enabled": {
-          "name": "Activate/Deactivate",
-          "description": "Should the selected slot be enabled or disabled."
-        },
-        "start": {
-          "name": "Start",
-          "description": "Set Start Time of the selected slot and day. Only needed if you want to enable a slot."
-        },
-        "end": {
-          "name": "End",
-          "description": "Set End Time of the selected slot and day. Only needed if you want to enable a slot."
-        }
-      }
     }
-  },
-  "selector": {
-    "calendar_type_options": {
-      "options": {
-        "calendar": "Manual Calendar",
-        "predictive": "SmartMowing predicted slots"
-      }
-    },
-    "day_options": {
-      "options": {
-        "monday": "Monday",
-        "tuesday": "Tuesday",
-        "wednesday": "Wednesday",
-        "thursday": "Thursday",
-        "friday": "Friday",
-        "saturday": "Saturday",
-        "sunday": "Sunday"
-      }
-    },
-    "command_options": {
-      "options": {
-        "mow": "Mow",
-        "return_to_dock": "Return to dock",
-        "pause": "Pause"
-      }
-    }
-  },
-  "issues": {
-    "auth_failure": {
-      "title": "Bosch Indego authentication expired",
-      "description": "Your authentication with Bosch Indego has expired. Please go to Settings > Devices & Services > Indego > Re-authenticate to restore access to your mower."
-    },
-    "connection_failure": {
-      "title": "Bosch Indego connection problems",
-      "description": "Your mower has not responded to API requests for an extended period. This may indicate network issues, the Bosch service is experiencing problems, or your mower is offline. Please check your internet connection and mower status."
-    }
-  }
 }

--- a/custom_components/boschindego/translations/en.json
+++ b/custom_components/boschindego/translations/en.json
@@ -320,7 +320,7 @@
             "predictive_calendar_slots": {
                 "name": "SmartMowing blocked times",
                 "state": {
-                    "Manual calendar active": "Manual calendar active",
+                    "manual calendar active": "Manual calendar active",
                     "off": "Off"
                 },
                 "state_attributes": {
@@ -362,7 +362,7 @@
             "predictive_schedule": {
                 "name": "SmartMowing schedule",
                 "state": {
-                    "Manual calendar active": "Manual calendar active",
+                    "manual calendar active": "Manual calendar active",
                     "none": "None"
                 },
                 "state_attributes": {

--- a/custom_components/boschindego/translations/es.json
+++ b/custom_components/boschindego/translations/es.json
@@ -152,7 +152,10 @@
                 "name": "Próximo corte"
             },
             "mowing_mode": {
-                "name": "Modo de corte"
+                "name": "Modo de corte",
+                "state": {
+                    "Calendar": "Calendario manual"
+                }
             },
             "runtime_total": {
                 "name": "Tiempo total de corte"
@@ -192,6 +195,332 @@
             },
             "battery_discharge": {
                 "name": "Descarga de batería"
+            },
+            "calendar_slots": {
+                "state": {
+                    "SmartMowing active": "SmartMowing activo",
+                    "off": "Apagado"
+                },
+                "name": "Tiempos de corte planificados",
+                "state_attributes": {
+                    "today_slot_1": {
+                        "name": "Intervalo de hoy 1",
+                        "state": {
+                            "not enabled": "No activado",
+                            "not configured": "No configurado"
+                        }
+                    },
+                    "today_slot_2": {
+                        "name": "Intervalo de hoy 2",
+                        "state": {
+                            "not enabled": "No activado",
+                            "not configured": "No configurado"
+                        }
+                    },
+                    "monday_slot_1": {
+                        "name": "Lunes Slot 1",
+                        "state": {
+                            "not enabled": "No activado",
+                            "not configured": "No configurado"
+                        }
+                    },
+                    "monday_slot_2": {
+                        "name": "Lunes Slot 2",
+                        "state": {
+                            "not enabled": "No activado",
+                            "not configured": "No configurado"
+                        }
+                    },
+                    "tuesday_slot_1": {
+                        "name": "Martes Slot 1",
+                        "state": {
+                            "not enabled": "No activado",
+                            "not configured": "No configurado"
+                        }
+                    },
+                    "tuesday_slot_2": {
+                        "name": "Martes Slot 2",
+                        "state": {
+                            "not enabled": "No activado",
+                            "not configured": "No configurado"
+                        }
+                    },
+                    "wednesday_slot_1": {
+                        "name": "Miércoles Slot 1",
+                        "state": {
+                            "not enabled": "No activado",
+                            "not configured": "No configurado"
+                        }
+                    },
+                    "wednesday_slot_2": {
+                        "name": "Miércoles Slot 2",
+                        "state": {
+                            "not enabled": "No activado",
+                            "not configured": "No configurado"
+                        }
+                    },
+                    "thursday_slot_1": {
+                        "name": "Jueves Slot 1",
+                        "state": {
+                            "not enabled": "No activado",
+                            "not configured": "No configurado"
+                        }
+                    },
+                    "thursday_slot_2": {
+                        "name": "Jueves Slot 2",
+                        "state": {
+                            "not enabled": "No activado",
+                            "not configured": "No configurado"
+                        }
+                    },
+                    "friday_slot_1": {
+                        "name": "Viernes Slot 1",
+                        "state": {
+                            "not enabled": "No activado",
+                            "not configured": "No configurado"
+                        }
+                    },
+                    "friday_slot_2": {
+                        "name": "Viernes Slot 2",
+                        "state": {
+                            "not enabled": "No activado",
+                            "not configured": "No configurado"
+                        }
+                    },
+                    "saturday_slot_1": {
+                        "name": "Sábado Slot 1",
+                        "state": {
+                            "not enabled": "No activado",
+                            "not configured": "No configurado"
+                        }
+                    },
+                    "saturday_slot_2": {
+                        "name": "Sábado Slot 2",
+                        "state": {
+                            "not enabled": "No activado",
+                            "not configured": "No configurado"
+                        }
+                    },
+                    "sunday_slot_1": {
+                        "name": "Domingo Slot 1",
+                        "state": {
+                            "not enabled": "No activado",
+                            "not configured": "No configurado"
+                        }
+                    },
+                    "sunday_slot_2": {
+                        "name": "Domingo Slot 2",
+                        "state": {
+                            "not enabled": "No activado",
+                            "not configured": "No configurado"
+                        }
+                    }
+                }
+            },
+            "predictive_calendar_slots": {
+                "name": "Períodos bloqueados de SmartMowing",
+                "state": {
+                    "Manual calendar active": "Calendario manual activo",
+                    "off": "Apagado"
+                },
+                "state_attributes": {
+                    "last_updated": {
+                        "name": "Última actualización"
+                    },
+                    "smartmowing_enabled": {
+                        "name": "SmartMowing activo"
+                    },
+                    "mowing_mode": {
+                        "name": "Modo de corte"
+                    },
+                    "earliest_start": {
+                        "name": "Inicio más temprano",
+                        "state": {
+                            "not enabled": "No activado"
+                        }
+                    },
+                    "latest_end": {
+                        "name": "Fin más tardío",
+                        "state": {
+                            "not enabled": "No activado"
+                        }
+                    },
+                    "blocked_before": {
+                        "name": "Bloqueado antes de",
+                        "state": {
+                            "not enabled": "No activado"
+                        }
+                    },
+                    "blocked_after": {
+                        "name": "Bloqueado después de",
+                        "state": {
+                            "not enabled": "No activado"
+                        }
+                    }
+                }
+            },
+            "predictive_schedule": {
+                "name": "Horario de SmartMowing",
+                "state": {
+                    "Manual calendar active": "Calendario manual activo",
+                    "none": "Ninguno"
+                },
+                "state_attributes": {
+                    "last_updated": {
+                        "name": "Última actualización"
+                    },
+                    "next_mow_slot": {
+                        "name": "Siguiente intervalo de corte planificado",
+                        "state": {
+                            "none": "Ninguno"
+                        }
+                    },
+                    "next_mow_day": {
+                        "name": "Siguiente día de corte planificado",
+                        "state": {
+                            "none": "Ninguno",
+                            "monday": "Lunes",
+                            "tuesday": "Martes",
+                            "wednesday": "Miércoles",
+                            "thursday": "Jueves",
+                            "friday": "Viernes",
+                            "saturday": "Sábado",
+                            "sunday": "Domingo"
+                        }
+                    },
+                    "next_mow_time": {
+                        "name": "Siguiente hora de corte planificada",
+                        "state": {
+                            "none": "Ninguno"
+                        }
+                    },
+                    "schedule_monday": {
+                        "name": "Horario Lunes",
+                        "state": {
+                            "not scheduled": "No programado"
+                        }
+                    },
+                    "exclusion_monday_user": {
+                        "name": "Período bloqueado Lunes usuario",
+                        "state": {
+                            "none": "Ninguno"
+                        }
+                    },
+                    "exclusion_monday_weather": {
+                        "name": "Período bloqueado Lunes clima",
+                        "state": {
+                            "none": "Ninguno"
+                        }
+                    },
+                    "schedule_tuesday": {
+                        "name": "Horario Martes",
+                        "state": {
+                            "not scheduled": "No programado"
+                        }
+                    },
+                    "exclusion_tuesday_user": {
+                        "name": "Período bloqueado Martes usuario",
+                        "state": {
+                            "none": "Ninguno"
+                        }
+                    },
+                    "exclusion_tuesday_weather": {
+                        "name": "Período bloqueado Martes clima",
+                        "state": {
+                            "none": "Ninguno"
+                        }
+                    },
+                    "schedule_wednesday": {
+                        "name": "Horario Miércoles",
+                        "state": {
+                            "not scheduled": "No programado"
+                        }
+                    },
+                    "exclusion_wednesday_user": {
+                        "name": "Período bloqueado Miércoles usuario",
+                        "state": {
+                            "none": "Ninguno"
+                        }
+                    },
+                    "exclusion_wednesday_weather": {
+                        "name": "Período bloqueado Miércoles clima",
+                        "state": {
+                            "none": "Ninguno"
+                        }
+                    },
+                    "schedule_thursday": {
+                        "name": "Horario Jueves",
+                        "state": {
+                            "not scheduled": "No programado"
+                        }
+                    },
+                    "exclusion_thursday_user": {
+                        "name": "Período bloqueado Jueves usuario",
+                        "state": {
+                            "none": "Ninguno"
+                        }
+                    },
+                    "exclusion_thursday_weather": {
+                        "name": "Período bloqueado Jueves clima",
+                        "state": {
+                            "none": "Ninguno"
+                        }
+                    },
+                    "schedule_friday": {
+                        "name": "Horario Viernes",
+                        "state": {
+                            "not scheduled": "No programado"
+                        }
+                    },
+                    "exclusion_friday_user": {
+                        "name": "Período bloqueado Viernes usuario",
+                        "state": {
+                            "none": "Ninguno"
+                        }
+                    },
+                    "exclusion_friday_weather": {
+                        "name": "Período bloqueado Viernes clima",
+                        "state": {
+                            "none": "Ninguno"
+                        }
+                    },
+                    "schedule_saturday": {
+                        "name": "Horario Sábado",
+                        "state": {
+                            "not scheduled": "No programado"
+                        }
+                    },
+                    "exclusion_saturday_user": {
+                        "name": "Período bloqueado Sábado usuario",
+                        "state": {
+                            "none": "Ninguno"
+                        }
+                    },
+                    "exclusion_saturday_weather": {
+                        "name": "Período bloqueado Sábado clima",
+                        "state": {
+                            "none": "Ninguno"
+                        }
+                    },
+                    "schedule_sunday": {
+                        "name": "Horario Domingo",
+                        "state": {
+                            "not scheduled": "No programado"
+                        }
+                    },
+                    "exclusion_sunday_user": {
+                        "name": "Período bloqueado Domingo usuario",
+                        "state": {
+                            "none": "Ninguno"
+                        }
+                    },
+                    "exclusion_sunday_weather": {
+                        "name": "Período bloqueado Domingo clima",
+                        "state": {
+                            "none": "Ninguno"
+                        }
+                    }
+                }
             }
         },
         "camera": {

--- a/custom_components/boschindego/translations/es.json
+++ b/custom_components/boschindego/translations/es.json
@@ -198,7 +198,7 @@
             },
             "calendar_slots": {
                 "state": {
-                    "smartmowing active": "SmartMowing activo",
+                    "smartmowing_active": "SmartMowing activo",
                     "off": "Apagado"
                 },
                 "name": "Tiempos de corte planificados",
@@ -206,113 +206,113 @@
                     "today_slot_1": {
                         "name": "Intervalo de hoy 1",
                         "state": {
-                            "not enabled": "No activado",
-                            "not configured": "No configurado"
+                            "not_enabled": "No activado",
+                            "not_configured": "No configurado"
                         }
                     },
                     "today_slot_2": {
                         "name": "Intervalo de hoy 2",
                         "state": {
-                            "not enabled": "No activado",
-                            "not configured": "No configurado"
+                            "not_enabled": "No activado",
+                            "not_configured": "No configurado"
                         }
                     },
                     "monday_slot_1": {
                         "name": "Lunes Slot 1",
                         "state": {
-                            "not enabled": "No activado",
-                            "not configured": "No configurado"
+                            "not_enabled": "No activado",
+                            "not_configured": "No configurado"
                         }
                     },
                     "monday_slot_2": {
                         "name": "Lunes Slot 2",
                         "state": {
-                            "not enabled": "No activado",
-                            "not configured": "No configurado"
+                            "not_enabled": "No activado",
+                            "not_configured": "No configurado"
                         }
                     },
                     "tuesday_slot_1": {
                         "name": "Martes Slot 1",
                         "state": {
-                            "not enabled": "No activado",
-                            "not configured": "No configurado"
+                            "not_enabled": "No activado",
+                            "not_configured": "No configurado"
                         }
                     },
                     "tuesday_slot_2": {
                         "name": "Martes Slot 2",
                         "state": {
-                            "not enabled": "No activado",
-                            "not configured": "No configurado"
+                            "not_enabled": "No activado",
+                            "not_configured": "No configurado"
                         }
                     },
                     "wednesday_slot_1": {
                         "name": "Miércoles Slot 1",
                         "state": {
-                            "not enabled": "No activado",
-                            "not configured": "No configurado"
+                            "not_enabled": "No activado",
+                            "not_configured": "No configurado"
                         }
                     },
                     "wednesday_slot_2": {
                         "name": "Miércoles Slot 2",
                         "state": {
-                            "not enabled": "No activado",
-                            "not configured": "No configurado"
+                            "not_enabled": "No activado",
+                            "not_configured": "No configurado"
                         }
                     },
                     "thursday_slot_1": {
                         "name": "Jueves Slot 1",
                         "state": {
-                            "not enabled": "No activado",
-                            "not configured": "No configurado"
+                            "not_enabled": "No activado",
+                            "not_configured": "No configurado"
                         }
                     },
                     "thursday_slot_2": {
                         "name": "Jueves Slot 2",
                         "state": {
-                            "not enabled": "No activado",
-                            "not configured": "No configurado"
+                            "not_enabled": "No activado",
+                            "not_configured": "No configurado"
                         }
                     },
                     "friday_slot_1": {
                         "name": "Viernes Slot 1",
                         "state": {
-                            "not enabled": "No activado",
-                            "not configured": "No configurado"
+                            "not_enabled": "No activado",
+                            "not_configured": "No configurado"
                         }
                     },
                     "friday_slot_2": {
                         "name": "Viernes Slot 2",
                         "state": {
-                            "not enabled": "No activado",
-                            "not configured": "No configurado"
+                            "not_enabled": "No activado",
+                            "not_configured": "No configurado"
                         }
                     },
                     "saturday_slot_1": {
                         "name": "Sábado Slot 1",
                         "state": {
-                            "not enabled": "No activado",
-                            "not configured": "No configurado"
+                            "not_enabled": "No activado",
+                            "not_configured": "No configurado"
                         }
                     },
                     "saturday_slot_2": {
                         "name": "Sábado Slot 2",
                         "state": {
-                            "not enabled": "No activado",
-                            "not configured": "No configurado"
+                            "not_enabled": "No activado",
+                            "not_configured": "No configurado"
                         }
                     },
                     "sunday_slot_1": {
                         "name": "Domingo Slot 1",
                         "state": {
-                            "not enabled": "No activado",
-                            "not configured": "No configurado"
+                            "not_enabled": "No activado",
+                            "not_configured": "No configurado"
                         }
                     },
                     "sunday_slot_2": {
                         "name": "Domingo Slot 2",
                         "state": {
-                            "not enabled": "No activado",
-                            "not configured": "No configurado"
+                            "not_enabled": "No activado",
+                            "not_configured": "No configurado"
                         }
                     }
                 }
@@ -320,7 +320,7 @@
             "predictive_calendar_slots": {
                 "name": "Períodos bloqueados de SmartMowing",
                 "state": {
-                    "manual calendar active": "Calendario manual activo",
+                    "manual_calendar_active": "Calendario manual activo",
                     "off": "Apagado"
                 },
                 "state_attributes": {
@@ -336,25 +336,25 @@
                     "earliest_start": {
                         "name": "Inicio más temprano",
                         "state": {
-                            "not enabled": "No activado"
+                            "not_enabled": "No activado"
                         }
                     },
                     "latest_end": {
                         "name": "Fin más tardío",
                         "state": {
-                            "not enabled": "No activado"
+                            "not_enabled": "No activado"
                         }
                     },
                     "blocked_before": {
                         "name": "Bloqueado antes de",
                         "state": {
-                            "not enabled": "No activado"
+                            "not_enabled": "No activado"
                         }
                     },
                     "blocked_after": {
                         "name": "Bloqueado después de",
                         "state": {
-                            "not enabled": "No activado"
+                            "not_enabled": "No activado"
                         }
                     }
                 }
@@ -362,7 +362,7 @@
             "predictive_schedule": {
                 "name": "Horario de SmartMowing",
                 "state": {
-                    "manual calendar active": "Calendario manual activo",
+                    "manual_calendar_active": "Calendario manual activo",
                     "none": "Ninguno"
                 },
                 "state_attributes": {
@@ -397,7 +397,7 @@
                     "schedule_monday": {
                         "name": "Horario Lunes",
                         "state": {
-                            "not scheduled": "No programado"
+                            "not_scheduled": "No programado"
                         }
                     },
                     "exclusion_monday_user": {
@@ -415,7 +415,7 @@
                     "schedule_tuesday": {
                         "name": "Horario Martes",
                         "state": {
-                            "not scheduled": "No programado"
+                            "not_scheduled": "No programado"
                         }
                     },
                     "exclusion_tuesday_user": {
@@ -433,7 +433,7 @@
                     "schedule_wednesday": {
                         "name": "Horario Miércoles",
                         "state": {
-                            "not scheduled": "No programado"
+                            "not_scheduled": "No programado"
                         }
                     },
                     "exclusion_wednesday_user": {
@@ -451,7 +451,7 @@
                     "schedule_thursday": {
                         "name": "Horario Jueves",
                         "state": {
-                            "not scheduled": "No programado"
+                            "not_scheduled": "No programado"
                         }
                     },
                     "exclusion_thursday_user": {
@@ -469,7 +469,7 @@
                     "schedule_friday": {
                         "name": "Horario Viernes",
                         "state": {
-                            "not scheduled": "No programado"
+                            "not_scheduled": "No programado"
                         }
                     },
                     "exclusion_friday_user": {
@@ -487,7 +487,7 @@
                     "schedule_saturday": {
                         "name": "Horario Sábado",
                         "state": {
-                            "not scheduled": "No programado"
+                            "not_scheduled": "No programado"
                         }
                     },
                     "exclusion_saturday_user": {
@@ -505,7 +505,7 @@
                     "schedule_sunday": {
                         "name": "Horario Domingo",
                         "state": {
-                            "not scheduled": "No programado"
+                            "not_scheduled": "No programado"
                         }
                     },
                     "exclusion_sunday_user": {

--- a/custom_components/boschindego/translations/es.json
+++ b/custom_components/boschindego/translations/es.json
@@ -154,7 +154,7 @@
             "mowing_mode": {
                 "name": "Modo de corte",
                 "state": {
-                    "Calendar": "Calendario manual"
+                    "calendar": "Calendario manual"
                 }
             },
             "runtime_total": {

--- a/custom_components/boschindego/translations/es.json
+++ b/custom_components/boschindego/translations/es.json
@@ -198,7 +198,7 @@
             },
             "calendar_slots": {
                 "state": {
-                    "SmartMowing active": "SmartMowing activo",
+                    "smartmowing active": "SmartMowing activo",
                     "off": "Apagado"
                 },
                 "name": "Tiempos de corte planificados",
@@ -320,7 +320,7 @@
             "predictive_calendar_slots": {
                 "name": "Períodos bloqueados de SmartMowing",
                 "state": {
-                    "Manual calendar active": "Calendario manual activo",
+                    "manual calendar active": "Calendario manual activo",
                     "off": "Apagado"
                 },
                 "state_attributes": {
@@ -362,7 +362,7 @@
             "predictive_schedule": {
                 "name": "Horario de SmartMowing",
                 "state": {
-                    "Manual calendar active": "Calendario manual activo",
+                    "manual calendar active": "Calendario manual activo",
                     "none": "Ninguno"
                 },
                 "state_attributes": {

--- a/custom_components/boschindego/translations/fr.json
+++ b/custom_components/boschindego/translations/fr.json
@@ -198,7 +198,7 @@
             },
             "calendar_slots": {
                 "state": {
-                    "smartmowing active": "SmartMowing actif",
+                    "smartmowing_active": "SmartMowing actif",
                     "off": "Désactivé"
                 },
                 "name": "Horaires de tonte planifiés",
@@ -206,113 +206,113 @@
                     "today_slot_1": {
                         "name": "Créneau aujourd'hui 1",
                         "state": {
-                            "not enabled": "Non activé",
-                            "not configured": "Non configuré"
+                            "not_enabled": "Non activé",
+                            "not_configured": "Non configuré"
                         }
                     },
                     "today_slot_2": {
                         "name": "Créneau aujourd'hui 2",
                         "state": {
-                            "not enabled": "Non activé",
-                            "not configured": "Non configuré"
+                            "not_enabled": "Non activé",
+                            "not_configured": "Non configuré"
                         }
                     },
                     "monday_slot_1": {
                         "name": "Lundi Slot 1",
                         "state": {
-                            "not enabled": "Non activé",
-                            "not configured": "Non configuré"
+                            "not_enabled": "Non activé",
+                            "not_configured": "Non configuré"
                         }
                     },
                     "monday_slot_2": {
                         "name": "Lundi Slot 2",
                         "state": {
-                            "not enabled": "Non activé",
-                            "not configured": "Non configuré"
+                            "not_enabled": "Non activé",
+                            "not_configured": "Non configuré"
                         }
                     },
                     "tuesday_slot_1": {
                         "name": "Mardi Slot 1",
                         "state": {
-                            "not enabled": "Non activé",
-                            "not configured": "Non configuré"
+                            "not_enabled": "Non activé",
+                            "not_configured": "Non configuré"
                         }
                     },
                     "tuesday_slot_2": {
                         "name": "Mardi Slot 2",
                         "state": {
-                            "not enabled": "Non activé",
-                            "not configured": "Non configuré"
+                            "not_enabled": "Non activé",
+                            "not_configured": "Non configuré"
                         }
                     },
                     "wednesday_slot_1": {
                         "name": "Mercredi Slot 1",
                         "state": {
-                            "not enabled": "Non activé",
-                            "not configured": "Non configuré"
+                            "not_enabled": "Non activé",
+                            "not_configured": "Non configuré"
                         }
                     },
                     "wednesday_slot_2": {
                         "name": "Mercredi Slot 2",
                         "state": {
-                            "not enabled": "Non activé",
-                            "not configured": "Non configuré"
+                            "not_enabled": "Non activé",
+                            "not_configured": "Non configuré"
                         }
                     },
                     "thursday_slot_1": {
                         "name": "Jeudi Slot 1",
                         "state": {
-                            "not enabled": "Non activé",
-                            "not configured": "Non configuré"
+                            "not_enabled": "Non activé",
+                            "not_configured": "Non configuré"
                         }
                     },
                     "thursday_slot_2": {
                         "name": "Jeudi Slot 2",
                         "state": {
-                            "not enabled": "Non activé",
-                            "not configured": "Non configuré"
+                            "not_enabled": "Non activé",
+                            "not_configured": "Non configuré"
                         }
                     },
                     "friday_slot_1": {
                         "name": "Vendredi Slot 1",
                         "state": {
-                            "not enabled": "Non activé",
-                            "not configured": "Non configuré"
+                            "not_enabled": "Non activé",
+                            "not_configured": "Non configuré"
                         }
                     },
                     "friday_slot_2": {
                         "name": "Vendredi Slot 2",
                         "state": {
-                            "not enabled": "Non activé",
-                            "not configured": "Non configuré"
+                            "not_enabled": "Non activé",
+                            "not_configured": "Non configuré"
                         }
                     },
                     "saturday_slot_1": {
                         "name": "Samedi Slot 1",
                         "state": {
-                            "not enabled": "Non activé",
-                            "not configured": "Non configuré"
+                            "not_enabled": "Non activé",
+                            "not_configured": "Non configuré"
                         }
                     },
                     "saturday_slot_2": {
                         "name": "Samedi Slot 2",
                         "state": {
-                            "not enabled": "Non activé",
-                            "not configured": "Non configuré"
+                            "not_enabled": "Non activé",
+                            "not_configured": "Non configuré"
                         }
                     },
                     "sunday_slot_1": {
                         "name": "Dimanche Slot 1",
                         "state": {
-                            "not enabled": "Non activé",
-                            "not configured": "Non configuré"
+                            "not_enabled": "Non activé",
+                            "not_configured": "Non configuré"
                         }
                     },
                     "sunday_slot_2": {
                         "name": "Dimanche Slot 2",
                         "state": {
-                            "not enabled": "Non activé",
-                            "not configured": "Non configuré"
+                            "not_enabled": "Non activé",
+                            "not_configured": "Non configuré"
                         }
                     }
                 }
@@ -320,7 +320,7 @@
             "predictive_calendar_slots": {
                 "name": "Périodes bloquées SmartMowing",
                 "state": {
-                    "manual calendar active": "Calendrier manuel actif",
+                    "manual_calendar_active": "Calendrier manuel actif",
                     "off": "Désactivé"
                 },
                 "state_attributes": {
@@ -336,25 +336,25 @@
                     "earliest_start": {
                         "name": "Début le plus tôt",
                         "state": {
-                            "not enabled": "Non activé"
+                            "not_enabled": "Non activé"
                         }
                     },
                     "latest_end": {
                         "name": "Fin au plus tard",
                         "state": {
-                            "not enabled": "Non activé"
+                            "not_enabled": "Non activé"
                         }
                     },
                     "blocked_before": {
                         "name": "Bloqué avant",
                         "state": {
-                            "not enabled": "Non activé"
+                            "not_enabled": "Non activé"
                         }
                     },
                     "blocked_after": {
                         "name": "Bloqué après",
                         "state": {
-                            "not enabled": "Non activé"
+                            "not_enabled": "Non activé"
                         }
                     }
                 }
@@ -362,7 +362,7 @@
             "predictive_schedule": {
                 "name": "Programme SmartMowing",
                 "state": {
-                    "manual calendar active": "Calendrier manuel actif",
+                    "manual_calendar_active": "Calendrier manuel actif",
                     "none": "Aucun"
                 },
                 "state_attributes": {
@@ -397,7 +397,7 @@
                     "schedule_monday": {
                         "name": "Programme Lundi",
                         "state": {
-                            "not scheduled": "Non planifié"
+                            "not_scheduled": "Non planifié"
                         }
                     },
                     "exclusion_monday_user": {
@@ -415,7 +415,7 @@
                     "schedule_tuesday": {
                         "name": "Programme Mardi",
                         "state": {
-                            "not scheduled": "Non planifié"
+                            "not_scheduled": "Non planifié"
                         }
                     },
                     "exclusion_tuesday_user": {
@@ -433,7 +433,7 @@
                     "schedule_wednesday": {
                         "name": "Programme Mercredi",
                         "state": {
-                            "not scheduled": "Non planifié"
+                            "not_scheduled": "Non planifié"
                         }
                     },
                     "exclusion_wednesday_user": {
@@ -451,7 +451,7 @@
                     "schedule_thursday": {
                         "name": "Programme Jeudi",
                         "state": {
-                            "not scheduled": "Non planifié"
+                            "not_scheduled": "Non planifié"
                         }
                     },
                     "exclusion_thursday_user": {
@@ -469,7 +469,7 @@
                     "schedule_friday": {
                         "name": "Programme Vendredi",
                         "state": {
-                            "not scheduled": "Non planifié"
+                            "not_scheduled": "Non planifié"
                         }
                     },
                     "exclusion_friday_user": {
@@ -487,7 +487,7 @@
                     "schedule_saturday": {
                         "name": "Programme Samedi",
                         "state": {
-                            "not scheduled": "Non planifié"
+                            "not_scheduled": "Non planifié"
                         }
                     },
                     "exclusion_saturday_user": {
@@ -505,7 +505,7 @@
                     "schedule_sunday": {
                         "name": "Programme Dimanche",
                         "state": {
-                            "not scheduled": "Non planifié"
+                            "not_scheduled": "Non planifié"
                         }
                     },
                     "exclusion_sunday_user": {

--- a/custom_components/boschindego/translations/fr.json
+++ b/custom_components/boschindego/translations/fr.json
@@ -198,7 +198,7 @@
             },
             "calendar_slots": {
                 "state": {
-                    "SmartMowing active": "SmartMowing actif",
+                    "smartmowing active": "SmartMowing actif",
                     "off": "Désactivé"
                 },
                 "name": "Horaires de tonte planifiés",
@@ -320,7 +320,7 @@
             "predictive_calendar_slots": {
                 "name": "Périodes bloquées SmartMowing",
                 "state": {
-                    "Manual calendar active": "Calendrier manuel actif",
+                    "manual calendar active": "Calendrier manuel actif",
                     "off": "Désactivé"
                 },
                 "state_attributes": {
@@ -362,7 +362,7 @@
             "predictive_schedule": {
                 "name": "Programme SmartMowing",
                 "state": {
-                    "Manual calendar active": "Calendrier manuel actif",
+                    "manual calendar active": "Calendrier manuel actif",
                     "none": "Aucun"
                 },
                 "state_attributes": {

--- a/custom_components/boschindego/translations/fr.json
+++ b/custom_components/boschindego/translations/fr.json
@@ -154,7 +154,7 @@
             "mowing_mode": {
                 "name": "Mode de tonte",
                 "state": {
-                    "Calendar": "Calendrier manuel"
+                    "calendar": "Calendrier manuel"
                 }
             },
             "runtime_total": {

--- a/custom_components/boschindego/translations/fr.json
+++ b/custom_components/boschindego/translations/fr.json
@@ -152,7 +152,10 @@
                 "name": "Prochain tontes"
             },
             "mowing_mode": {
-                "name": "Mode de tonte"
+                "name": "Mode de tonte",
+                "state": {
+                    "Calendar": "Calendrier manuel"
+                }
             },
             "runtime_total": {
                 "name": "Temps de tontes total"
@@ -192,6 +195,332 @@
             },
             "battery_discharge": {
                 "name": "Décharge batterie"
+            },
+            "calendar_slots": {
+                "state": {
+                    "SmartMowing active": "SmartMowing actif",
+                    "off": "Désactivé"
+                },
+                "name": "Horaires de tonte planifiés",
+                "state_attributes": {
+                    "today_slot_1": {
+                        "name": "Créneau aujourd'hui 1",
+                        "state": {
+                            "not enabled": "Non activé",
+                            "not configured": "Non configuré"
+                        }
+                    },
+                    "today_slot_2": {
+                        "name": "Créneau aujourd'hui 2",
+                        "state": {
+                            "not enabled": "Non activé",
+                            "not configured": "Non configuré"
+                        }
+                    },
+                    "monday_slot_1": {
+                        "name": "Lundi Slot 1",
+                        "state": {
+                            "not enabled": "Non activé",
+                            "not configured": "Non configuré"
+                        }
+                    },
+                    "monday_slot_2": {
+                        "name": "Lundi Slot 2",
+                        "state": {
+                            "not enabled": "Non activé",
+                            "not configured": "Non configuré"
+                        }
+                    },
+                    "tuesday_slot_1": {
+                        "name": "Mardi Slot 1",
+                        "state": {
+                            "not enabled": "Non activé",
+                            "not configured": "Non configuré"
+                        }
+                    },
+                    "tuesday_slot_2": {
+                        "name": "Mardi Slot 2",
+                        "state": {
+                            "not enabled": "Non activé",
+                            "not configured": "Non configuré"
+                        }
+                    },
+                    "wednesday_slot_1": {
+                        "name": "Mercredi Slot 1",
+                        "state": {
+                            "not enabled": "Non activé",
+                            "not configured": "Non configuré"
+                        }
+                    },
+                    "wednesday_slot_2": {
+                        "name": "Mercredi Slot 2",
+                        "state": {
+                            "not enabled": "Non activé",
+                            "not configured": "Non configuré"
+                        }
+                    },
+                    "thursday_slot_1": {
+                        "name": "Jeudi Slot 1",
+                        "state": {
+                            "not enabled": "Non activé",
+                            "not configured": "Non configuré"
+                        }
+                    },
+                    "thursday_slot_2": {
+                        "name": "Jeudi Slot 2",
+                        "state": {
+                            "not enabled": "Non activé",
+                            "not configured": "Non configuré"
+                        }
+                    },
+                    "friday_slot_1": {
+                        "name": "Vendredi Slot 1",
+                        "state": {
+                            "not enabled": "Non activé",
+                            "not configured": "Non configuré"
+                        }
+                    },
+                    "friday_slot_2": {
+                        "name": "Vendredi Slot 2",
+                        "state": {
+                            "not enabled": "Non activé",
+                            "not configured": "Non configuré"
+                        }
+                    },
+                    "saturday_slot_1": {
+                        "name": "Samedi Slot 1",
+                        "state": {
+                            "not enabled": "Non activé",
+                            "not configured": "Non configuré"
+                        }
+                    },
+                    "saturday_slot_2": {
+                        "name": "Samedi Slot 2",
+                        "state": {
+                            "not enabled": "Non activé",
+                            "not configured": "Non configuré"
+                        }
+                    },
+                    "sunday_slot_1": {
+                        "name": "Dimanche Slot 1",
+                        "state": {
+                            "not enabled": "Non activé",
+                            "not configured": "Non configuré"
+                        }
+                    },
+                    "sunday_slot_2": {
+                        "name": "Dimanche Slot 2",
+                        "state": {
+                            "not enabled": "Non activé",
+                            "not configured": "Non configuré"
+                        }
+                    }
+                }
+            },
+            "predictive_calendar_slots": {
+                "name": "Périodes bloquées SmartMowing",
+                "state": {
+                    "Manual calendar active": "Calendrier manuel actif",
+                    "off": "Désactivé"
+                },
+                "state_attributes": {
+                    "last_updated": {
+                        "name": "Dernière mise à jour"
+                    },
+                    "smartmowing_enabled": {
+                        "name": "SmartMowing actif"
+                    },
+                    "mowing_mode": {
+                        "name": "Mode de tonte"
+                    },
+                    "earliest_start": {
+                        "name": "Début le plus tôt",
+                        "state": {
+                            "not enabled": "Non activé"
+                        }
+                    },
+                    "latest_end": {
+                        "name": "Fin au plus tard",
+                        "state": {
+                            "not enabled": "Non activé"
+                        }
+                    },
+                    "blocked_before": {
+                        "name": "Bloqué avant",
+                        "state": {
+                            "not enabled": "Non activé"
+                        }
+                    },
+                    "blocked_after": {
+                        "name": "Bloqué après",
+                        "state": {
+                            "not enabled": "Non activé"
+                        }
+                    }
+                }
+            },
+            "predictive_schedule": {
+                "name": "Programme SmartMowing",
+                "state": {
+                    "Manual calendar active": "Calendrier manuel actif",
+                    "none": "Aucun"
+                },
+                "state_attributes": {
+                    "last_updated": {
+                        "name": "Dernière mise à jour"
+                    },
+                    "next_mow_slot": {
+                        "name": "Prochain créneau de tonte planifié",
+                        "state": {
+                            "none": "Aucun"
+                        }
+                    },
+                    "next_mow_day": {
+                        "name": "Prochain jour de tonte planifié",
+                        "state": {
+                            "none": "Aucun",
+                            "monday": "Lundi",
+                            "tuesday": "Mardi",
+                            "wednesday": "Mercredi",
+                            "thursday": "Jeudi",
+                            "friday": "Vendredi",
+                            "saturday": "Samedi",
+                            "sunday": "Dimanche"
+                        }
+                    },
+                    "next_mow_time": {
+                        "name": "Prochaine heure de tonte planifiée",
+                        "state": {
+                            "none": "Aucun"
+                        }
+                    },
+                    "schedule_monday": {
+                        "name": "Programme Lundi",
+                        "state": {
+                            "not scheduled": "Non planifié"
+                        }
+                    },
+                    "exclusion_monday_user": {
+                        "name": "Période bloquée Lundi utilisateur",
+                        "state": {
+                            "none": "Aucun"
+                        }
+                    },
+                    "exclusion_monday_weather": {
+                        "name": "Période bloquée Lundi météo",
+                        "state": {
+                            "none": "Aucun"
+                        }
+                    },
+                    "schedule_tuesday": {
+                        "name": "Programme Mardi",
+                        "state": {
+                            "not scheduled": "Non planifié"
+                        }
+                    },
+                    "exclusion_tuesday_user": {
+                        "name": "Période bloquée Mardi utilisateur",
+                        "state": {
+                            "none": "Aucun"
+                        }
+                    },
+                    "exclusion_tuesday_weather": {
+                        "name": "Période bloquée Mardi météo",
+                        "state": {
+                            "none": "Aucun"
+                        }
+                    },
+                    "schedule_wednesday": {
+                        "name": "Programme Mercredi",
+                        "state": {
+                            "not scheduled": "Non planifié"
+                        }
+                    },
+                    "exclusion_wednesday_user": {
+                        "name": "Période bloquée Mercredi utilisateur",
+                        "state": {
+                            "none": "Aucun"
+                        }
+                    },
+                    "exclusion_wednesday_weather": {
+                        "name": "Période bloquée Mercredi météo",
+                        "state": {
+                            "none": "Aucun"
+                        }
+                    },
+                    "schedule_thursday": {
+                        "name": "Programme Jeudi",
+                        "state": {
+                            "not scheduled": "Non planifié"
+                        }
+                    },
+                    "exclusion_thursday_user": {
+                        "name": "Période bloquée Jeudi utilisateur",
+                        "state": {
+                            "none": "Aucun"
+                        }
+                    },
+                    "exclusion_thursday_weather": {
+                        "name": "Période bloquée Jeudi météo",
+                        "state": {
+                            "none": "Aucun"
+                        }
+                    },
+                    "schedule_friday": {
+                        "name": "Programme Vendredi",
+                        "state": {
+                            "not scheduled": "Non planifié"
+                        }
+                    },
+                    "exclusion_friday_user": {
+                        "name": "Période bloquée Vendredi utilisateur",
+                        "state": {
+                            "none": "Aucun"
+                        }
+                    },
+                    "exclusion_friday_weather": {
+                        "name": "Période bloquée Vendredi météo",
+                        "state": {
+                            "none": "Aucun"
+                        }
+                    },
+                    "schedule_saturday": {
+                        "name": "Programme Samedi",
+                        "state": {
+                            "not scheduled": "Non planifié"
+                        }
+                    },
+                    "exclusion_saturday_user": {
+                        "name": "Période bloquée Samedi utilisateur",
+                        "state": {
+                            "none": "Aucun"
+                        }
+                    },
+                    "exclusion_saturday_weather": {
+                        "name": "Période bloquée Samedi météo",
+                        "state": {
+                            "none": "Aucun"
+                        }
+                    },
+                    "schedule_sunday": {
+                        "name": "Programme Dimanche",
+                        "state": {
+                            "not scheduled": "Non planifié"
+                        }
+                    },
+                    "exclusion_sunday_user": {
+                        "name": "Période bloquée Dimanche utilisateur",
+                        "state": {
+                            "none": "Aucun"
+                        }
+                    },
+                    "exclusion_sunday_weather": {
+                        "name": "Période bloquée Dimanche météo",
+                        "state": {
+                            "none": "Aucun"
+                        }
+                    }
+                }
             }
         },
         "camera": {

--- a/custom_components/boschindego/translations/it.json
+++ b/custom_components/boschindego/translations/it.json
@@ -154,7 +154,7 @@
             "mowing_mode": {
                 "name": "Modalità di taglio",
                 "state": {
-                    "Calendar": "Calendario manuale"
+                    "calendar": "Calendario manuale"
                 }
             },
             "runtime_total": {
@@ -198,7 +198,7 @@
             },
             "calendar_slots": {
                 "state": {
-                    "smartmowing active": "SmartMowing attivo",
+                    "smartmowing_active": "SmartMowing attivo",
                     "off": "Spento"
                 },
                 "name": "Orari di taglio pianificati",
@@ -206,113 +206,113 @@
                     "today_slot_1": {
                         "name": "Slot di oggi 1",
                         "state": {
-                            "not enabled": "Non attivato",
-                            "not configured": "Non configurato"
+                            "not_enabled": "Non attivato",
+                            "not_configured": "Non configurato"
                         }
                     },
                     "today_slot_2": {
                         "name": "Slot di oggi 2",
                         "state": {
-                            "not enabled": "Non attivato",
-                            "not configured": "Non configurato"
+                            "not_enabled": "Non attivato",
+                            "not_configured": "Non configurato"
                         }
                     },
                     "monday_slot_1": {
                         "name": "Lunedì Slot 1",
                         "state": {
-                            "not enabled": "Non attivato",
-                            "not configured": "Non configurato"
+                            "not_enabled": "Non attivato",
+                            "not_configured": "Non configurato"
                         }
                     },
                     "monday_slot_2": {
                         "name": "Lunedì Slot 2",
                         "state": {
-                            "not enabled": "Non attivato",
-                            "not configured": "Non configurato"
+                            "not_enabled": "Non attivato",
+                            "not_configured": "Non configurato"
                         }
                     },
                     "tuesday_slot_1": {
                         "name": "Martedì Slot 1",
                         "state": {
-                            "not enabled": "Non attivato",
-                            "not configured": "Non configurato"
+                            "not_enabled": "Non attivato",
+                            "not_configured": "Non configurato"
                         }
                     },
                     "tuesday_slot_2": {
                         "name": "Martedì Slot 2",
                         "state": {
-                            "not enabled": "Non attivato",
-                            "not configured": "Non configurato"
+                            "not_enabled": "Non attivato",
+                            "not_configured": "Non configurato"
                         }
                     },
                     "wednesday_slot_1": {
                         "name": "Mercoledì Slot 1",
                         "state": {
-                            "not enabled": "Non attivato",
-                            "not configured": "Non configurato"
+                            "not_enabled": "Non attivato",
+                            "not_configured": "Non configurato"
                         }
                     },
                     "wednesday_slot_2": {
                         "name": "Mercoledì Slot 2",
                         "state": {
-                            "not enabled": "Non attivato",
-                            "not configured": "Non configurato"
+                            "not_enabled": "Non attivato",
+                            "not_configured": "Non configurato"
                         }
                     },
                     "thursday_slot_1": {
                         "name": "Giovedì Slot 1",
                         "state": {
-                            "not enabled": "Non attivato",
-                            "not configured": "Non configurato"
+                            "not_enabled": "Non attivato",
+                            "not_configured": "Non configurato"
                         }
                     },
                     "thursday_slot_2": {
                         "name": "Giovedì Slot 2",
                         "state": {
-                            "not enabled": "Non attivato",
-                            "not configured": "Non configurato"
+                            "not_enabled": "Non attivato",
+                            "not_configured": "Non configurato"
                         }
                     },
                     "friday_slot_1": {
                         "name": "Venerdì Slot 1",
                         "state": {
-                            "not enabled": "Non attivato",
-                            "not configured": "Non configurato"
+                            "not_enabled": "Non attivato",
+                            "not_configured": "Non configurato"
                         }
                     },
                     "friday_slot_2": {
                         "name": "Venerdì Slot 2",
                         "state": {
-                            "not enabled": "Non attivato",
-                            "not configured": "Non configurato"
+                            "not_enabled": "Non attivato",
+                            "not_configured": "Non configurato"
                         }
                     },
                     "saturday_slot_1": {
                         "name": "Sabato Slot 1",
                         "state": {
-                            "not enabled": "Non attivato",
-                            "not configured": "Non configurato"
+                            "not_enabled": "Non attivato",
+                            "not_configured": "Non configurato"
                         }
                     },
                     "saturday_slot_2": {
                         "name": "Sabato Slot 2",
                         "state": {
-                            "not enabled": "Non attivato",
-                            "not configured": "Non configurato"
+                            "not_enabled": "Non attivato",
+                            "not_configured": "Non configurato"
                         }
                     },
                     "sunday_slot_1": {
                         "name": "Domenica Slot 1",
                         "state": {
-                            "not enabled": "Non attivato",
-                            "not configured": "Non configurato"
+                            "not_enabled": "Non attivato",
+                            "not_configured": "Non configurato"
                         }
                     },
                     "sunday_slot_2": {
                         "name": "Domenica Slot 2",
                         "state": {
-                            "not enabled": "Non attivato",
-                            "not configured": "Non configurato"
+                            "not_enabled": "Non attivato",
+                            "not_configured": "Non configurato"
                         }
                     }
                 }
@@ -320,7 +320,7 @@
             "predictive_calendar_slots": {
                 "name": "Periodi bloccati SmartMowing",
                 "state": {
-                    "manual calendar active": "Calendario manuale attivo",
+                    "manual_calendar_active": "Calendario manuale attivo",
                     "off": "Spento"
                 },
                 "state_attributes": {
@@ -336,25 +336,25 @@
                     "earliest_start": {
                         "name": "Inizio più anticipato",
                         "state": {
-                            "not enabled": "Non attivato"
+                            "not_enabled": "Non attivato"
                         }
                     },
                     "latest_end": {
                         "name": "Fine più tardiva",
                         "state": {
-                            "not enabled": "Non attivato"
+                            "not_enabled": "Non attivato"
                         }
                     },
                     "blocked_before": {
                         "name": "Bloccato prima di",
                         "state": {
-                            "not enabled": "Non attivato"
+                            "not_enabled": "Non attivato"
                         }
                     },
                     "blocked_after": {
                         "name": "Bloccato dopo",
                         "state": {
-                            "not enabled": "Non attivato"
+                            "not_enabled": "Non attivato"
                         }
                     }
                 }
@@ -362,7 +362,7 @@
             "predictive_schedule": {
                 "name": "Programma SmartMowing",
                 "state": {
-                    "manual calendar active": "Calendario manuale attivo",
+                    "manual_calendar_active": "Calendario manuale attivo",
                     "none": "Nessuno"
                 },
                 "state_attributes": {
@@ -397,7 +397,7 @@
                     "schedule_monday": {
                         "name": "Programma Lunedì",
                         "state": {
-                            "not scheduled": "Non programmato"
+                            "not_scheduled": "Non programmato"
                         }
                     },
                     "exclusion_monday_user": {
@@ -415,7 +415,7 @@
                     "schedule_tuesday": {
                         "name": "Programma Martedì",
                         "state": {
-                            "not scheduled": "Non programmato"
+                            "not_scheduled": "Non programmato"
                         }
                     },
                     "exclusion_tuesday_user": {
@@ -433,7 +433,7 @@
                     "schedule_wednesday": {
                         "name": "Programma Mercoledì",
                         "state": {
-                            "not scheduled": "Non programmato"
+                            "not_scheduled": "Non programmato"
                         }
                     },
                     "exclusion_wednesday_user": {
@@ -451,7 +451,7 @@
                     "schedule_thursday": {
                         "name": "Programma Giovedì",
                         "state": {
-                            "not scheduled": "Non programmato"
+                            "not_scheduled": "Non programmato"
                         }
                     },
                     "exclusion_thursday_user": {
@@ -469,7 +469,7 @@
                     "schedule_friday": {
                         "name": "Programma Venerdì",
                         "state": {
-                            "not scheduled": "Non programmato"
+                            "not_scheduled": "Non programmato"
                         }
                     },
                     "exclusion_friday_user": {
@@ -487,7 +487,7 @@
                     "schedule_saturday": {
                         "name": "Programma Sabato",
                         "state": {
-                            "not scheduled": "Non programmato"
+                            "not_scheduled": "Non programmato"
                         }
                     },
                     "exclusion_saturday_user": {
@@ -505,7 +505,7 @@
                     "schedule_sunday": {
                         "name": "Programma Domenica",
                         "state": {
-                            "not scheduled": "Non programmato"
+                            "not_scheduled": "Non programmato"
                         }
                     },
                     "exclusion_sunday_user": {

--- a/custom_components/boschindego/translations/it.json
+++ b/custom_components/boschindego/translations/it.json
@@ -198,7 +198,7 @@
             },
             "calendar_slots": {
                 "state": {
-                    "SmartMowing active": "SmartMowing attivo",
+                    "smartmowing active": "SmartMowing attivo",
                     "off": "Spento"
                 },
                 "name": "Orari di taglio pianificati",
@@ -320,7 +320,7 @@
             "predictive_calendar_slots": {
                 "name": "Periodi bloccati SmartMowing",
                 "state": {
-                    "Manual calendar active": "Calendario manuale attivo",
+                    "manual calendar active": "Calendario manuale attivo",
                     "off": "Spento"
                 },
                 "state_attributes": {
@@ -362,7 +362,7 @@
             "predictive_schedule": {
                 "name": "Programma SmartMowing",
                 "state": {
-                    "Manual calendar active": "Calendario manuale attivo",
+                    "manual calendar active": "Calendario manuale attivo",
                     "none": "Nessuno"
                 },
                 "state_attributes": {

--- a/custom_components/boschindego/translations/it.json
+++ b/custom_components/boschindego/translations/it.json
@@ -152,7 +152,10 @@
                 "name": "Prossimo taglio"
             },
             "mowing_mode": {
-                "name": "Modalità di taglio"
+                "name": "Modalità di taglio",
+                "state": {
+                    "Calendar": "Calendario manuale"
+                }
             },
             "runtime_total": {
                 "name": "Tempo totale di taglio"
@@ -192,6 +195,332 @@
             },
             "battery_discharge": {
                 "name": "Scarica batteria"
+            },
+            "calendar_slots": {
+                "state": {
+                    "SmartMowing active": "SmartMowing attivo",
+                    "off": "Spento"
+                },
+                "name": "Orari di taglio pianificati",
+                "state_attributes": {
+                    "today_slot_1": {
+                        "name": "Slot di oggi 1",
+                        "state": {
+                            "not enabled": "Non attivato",
+                            "not configured": "Non configurato"
+                        }
+                    },
+                    "today_slot_2": {
+                        "name": "Slot di oggi 2",
+                        "state": {
+                            "not enabled": "Non attivato",
+                            "not configured": "Non configurato"
+                        }
+                    },
+                    "monday_slot_1": {
+                        "name": "Lunedì Slot 1",
+                        "state": {
+                            "not enabled": "Non attivato",
+                            "not configured": "Non configurato"
+                        }
+                    },
+                    "monday_slot_2": {
+                        "name": "Lunedì Slot 2",
+                        "state": {
+                            "not enabled": "Non attivato",
+                            "not configured": "Non configurato"
+                        }
+                    },
+                    "tuesday_slot_1": {
+                        "name": "Martedì Slot 1",
+                        "state": {
+                            "not enabled": "Non attivato",
+                            "not configured": "Non configurato"
+                        }
+                    },
+                    "tuesday_slot_2": {
+                        "name": "Martedì Slot 2",
+                        "state": {
+                            "not enabled": "Non attivato",
+                            "not configured": "Non configurato"
+                        }
+                    },
+                    "wednesday_slot_1": {
+                        "name": "Mercoledì Slot 1",
+                        "state": {
+                            "not enabled": "Non attivato",
+                            "not configured": "Non configurato"
+                        }
+                    },
+                    "wednesday_slot_2": {
+                        "name": "Mercoledì Slot 2",
+                        "state": {
+                            "not enabled": "Non attivato",
+                            "not configured": "Non configurato"
+                        }
+                    },
+                    "thursday_slot_1": {
+                        "name": "Giovedì Slot 1",
+                        "state": {
+                            "not enabled": "Non attivato",
+                            "not configured": "Non configurato"
+                        }
+                    },
+                    "thursday_slot_2": {
+                        "name": "Giovedì Slot 2",
+                        "state": {
+                            "not enabled": "Non attivato",
+                            "not configured": "Non configurato"
+                        }
+                    },
+                    "friday_slot_1": {
+                        "name": "Venerdì Slot 1",
+                        "state": {
+                            "not enabled": "Non attivato",
+                            "not configured": "Non configurato"
+                        }
+                    },
+                    "friday_slot_2": {
+                        "name": "Venerdì Slot 2",
+                        "state": {
+                            "not enabled": "Non attivato",
+                            "not configured": "Non configurato"
+                        }
+                    },
+                    "saturday_slot_1": {
+                        "name": "Sabato Slot 1",
+                        "state": {
+                            "not enabled": "Non attivato",
+                            "not configured": "Non configurato"
+                        }
+                    },
+                    "saturday_slot_2": {
+                        "name": "Sabato Slot 2",
+                        "state": {
+                            "not enabled": "Non attivato",
+                            "not configured": "Non configurato"
+                        }
+                    },
+                    "sunday_slot_1": {
+                        "name": "Domenica Slot 1",
+                        "state": {
+                            "not enabled": "Non attivato",
+                            "not configured": "Non configurato"
+                        }
+                    },
+                    "sunday_slot_2": {
+                        "name": "Domenica Slot 2",
+                        "state": {
+                            "not enabled": "Non attivato",
+                            "not configured": "Non configurato"
+                        }
+                    }
+                }
+            },
+            "predictive_calendar_slots": {
+                "name": "Periodi bloccati SmartMowing",
+                "state": {
+                    "Manual calendar active": "Calendario manuale attivo",
+                    "off": "Spento"
+                },
+                "state_attributes": {
+                    "last_updated": {
+                        "name": "Ultimo aggiornamento"
+                    },
+                    "smartmowing_enabled": {
+                        "name": "SmartMowing attivo"
+                    },
+                    "mowing_mode": {
+                        "name": "Modalità di taglio"
+                    },
+                    "earliest_start": {
+                        "name": "Inizio più anticipato",
+                        "state": {
+                            "not enabled": "Non attivato"
+                        }
+                    },
+                    "latest_end": {
+                        "name": "Fine più tardiva",
+                        "state": {
+                            "not enabled": "Non attivato"
+                        }
+                    },
+                    "blocked_before": {
+                        "name": "Bloccato prima di",
+                        "state": {
+                            "not enabled": "Non attivato"
+                        }
+                    },
+                    "blocked_after": {
+                        "name": "Bloccato dopo",
+                        "state": {
+                            "not enabled": "Non attivato"
+                        }
+                    }
+                }
+            },
+            "predictive_schedule": {
+                "name": "Programma SmartMowing",
+                "state": {
+                    "Manual calendar active": "Calendario manuale attivo",
+                    "none": "Nessuno"
+                },
+                "state_attributes": {
+                    "last_updated": {
+                        "name": "Ultimo aggiornamento"
+                    },
+                    "next_mow_slot": {
+                        "name": "Prossima fascia di taglio pianificata",
+                        "state": {
+                            "none": "Nessuno"
+                        }
+                    },
+                    "next_mow_day": {
+                        "name": "Prossimo giorno di taglio pianificato",
+                        "state": {
+                            "none": "Nessuno",
+                            "monday": "Lunedì",
+                            "tuesday": "Martedì",
+                            "wednesday": "Mercoledì",
+                            "thursday": "Giovedì",
+                            "friday": "Venerdì",
+                            "saturday": "Sabato",
+                            "sunday": "Domenica"
+                        }
+                    },
+                    "next_mow_time": {
+                        "name": "Prossimo orario di taglio pianificato",
+                        "state": {
+                            "none": "Nessuno"
+                        }
+                    },
+                    "schedule_monday": {
+                        "name": "Programma Lunedì",
+                        "state": {
+                            "not scheduled": "Non programmato"
+                        }
+                    },
+                    "exclusion_monday_user": {
+                        "name": "Periodo bloccato Lunedì utente",
+                        "state": {
+                            "none": "Nessuno"
+                        }
+                    },
+                    "exclusion_monday_weather": {
+                        "name": "Periodo bloccato Lunedì meteo",
+                        "state": {
+                            "none": "Nessuno"
+                        }
+                    },
+                    "schedule_tuesday": {
+                        "name": "Programma Martedì",
+                        "state": {
+                            "not scheduled": "Non programmato"
+                        }
+                    },
+                    "exclusion_tuesday_user": {
+                        "name": "Periodo bloccato Martedì utente",
+                        "state": {
+                            "none": "Nessuno"
+                        }
+                    },
+                    "exclusion_tuesday_weather": {
+                        "name": "Periodo bloccato Martedì meteo",
+                        "state": {
+                            "none": "Nessuno"
+                        }
+                    },
+                    "schedule_wednesday": {
+                        "name": "Programma Mercoledì",
+                        "state": {
+                            "not scheduled": "Non programmato"
+                        }
+                    },
+                    "exclusion_wednesday_user": {
+                        "name": "Periodo bloccato Mercoledì utente",
+                        "state": {
+                            "none": "Nessuno"
+                        }
+                    },
+                    "exclusion_wednesday_weather": {
+                        "name": "Periodo bloccato Mercoledì meteo",
+                        "state": {
+                            "none": "Nessuno"
+                        }
+                    },
+                    "schedule_thursday": {
+                        "name": "Programma Giovedì",
+                        "state": {
+                            "not scheduled": "Non programmato"
+                        }
+                    },
+                    "exclusion_thursday_user": {
+                        "name": "Periodo bloccato Giovedì utente",
+                        "state": {
+                            "none": "Nessuno"
+                        }
+                    },
+                    "exclusion_thursday_weather": {
+                        "name": "Periodo bloccato Giovedì meteo",
+                        "state": {
+                            "none": "Nessuno"
+                        }
+                    },
+                    "schedule_friday": {
+                        "name": "Programma Venerdì",
+                        "state": {
+                            "not scheduled": "Non programmato"
+                        }
+                    },
+                    "exclusion_friday_user": {
+                        "name": "Periodo bloccato Venerdì utente",
+                        "state": {
+                            "none": "Nessuno"
+                        }
+                    },
+                    "exclusion_friday_weather": {
+                        "name": "Periodo bloccato Venerdì meteo",
+                        "state": {
+                            "none": "Nessuno"
+                        }
+                    },
+                    "schedule_saturday": {
+                        "name": "Programma Sabato",
+                        "state": {
+                            "not scheduled": "Non programmato"
+                        }
+                    },
+                    "exclusion_saturday_user": {
+                        "name": "Periodo bloccato Sabato utente",
+                        "state": {
+                            "none": "Nessuno"
+                        }
+                    },
+                    "exclusion_saturday_weather": {
+                        "name": "Periodo bloccato Sabato meteo",
+                        "state": {
+                            "none": "Nessuno"
+                        }
+                    },
+                    "schedule_sunday": {
+                        "name": "Programma Domenica",
+                        "state": {
+                            "not scheduled": "Non programmato"
+                        }
+                    },
+                    "exclusion_sunday_user": {
+                        "name": "Periodo bloccato Domenica utente",
+                        "state": {
+                            "none": "Nessuno"
+                        }
+                    },
+                    "exclusion_sunday_weather": {
+                        "name": "Periodo bloccato Domenica meteo",
+                        "state": {
+                            "none": "Nessuno"
+                        }
+                    }
+                }
             }
         },
         "camera": {

--- a/custom_components/boschindego/translations/nl.json
+++ b/custom_components/boschindego/translations/nl.json
@@ -198,7 +198,7 @@
             },
             "calendar_slots": {
                 "state": {
-                    "SmartMowing active": "SmartMowing actief",
+                    "smartmowing active": "SmartMowing actief",
                     "off": "Uit"
                 },
                 "name": "Geplande maaitijden",
@@ -320,7 +320,7 @@
             "predictive_calendar_slots": {
                 "name": "SmartMowing-blokkeertijden",
                 "state": {
-                    "Manual calendar active": "Handmatige kalender actief",
+                    "manual calendar active": "Handmatige kalender actief",
                     "off": "Uit"
                 },
                 "state_attributes": {
@@ -362,7 +362,7 @@
             "predictive_schedule": {
                 "name": "SmartMowing-schema",
                 "state": {
-                    "Manual calendar active": "Handmatige kalender actief",
+                    "manual calendar active": "Handmatige kalender actief",
                     "none": "Geen"
                 },
                 "state_attributes": {

--- a/custom_components/boschindego/translations/nl.json
+++ b/custom_components/boschindego/translations/nl.json
@@ -152,7 +152,10 @@
                 "name": "Volgende maaien"
             },
             "mowing_mode": {
-                "name": "Maaimode"
+                "name": "Maaimode",
+                "state": {
+                    "Calendar": "Handmatige kalender"
+                }
             },
             "runtime_total": {
                 "name": "Totale maaibedrijf"
@@ -192,6 +195,332 @@
             },
             "battery_discharge": {
                 "name": "Batterijontlading"
+            },
+            "calendar_slots": {
+                "state": {
+                    "SmartMowing active": "SmartMowing actief",
+                    "off": "Uit"
+                },
+                "name": "Geplande maaitijden",
+                "state_attributes": {
+                    "today_slot_1": {
+                        "name": "Vandaag slot 1",
+                        "state": {
+                            "not enabled": "Niet ingeschakeld",
+                            "not configured": "Niet geconfigureerd"
+                        }
+                    },
+                    "today_slot_2": {
+                        "name": "Vandaag slot 2",
+                        "state": {
+                            "not enabled": "Niet ingeschakeld",
+                            "not configured": "Niet geconfigureerd"
+                        }
+                    },
+                    "monday_slot_1": {
+                        "name": "Maandag Slot 1",
+                        "state": {
+                            "not enabled": "Niet ingeschakeld",
+                            "not configured": "Niet geconfigureerd"
+                        }
+                    },
+                    "monday_slot_2": {
+                        "name": "Maandag Slot 2",
+                        "state": {
+                            "not enabled": "Niet ingeschakeld",
+                            "not configured": "Niet geconfigureerd"
+                        }
+                    },
+                    "tuesday_slot_1": {
+                        "name": "Dinsdag Slot 1",
+                        "state": {
+                            "not enabled": "Niet ingeschakeld",
+                            "not configured": "Niet geconfigureerd"
+                        }
+                    },
+                    "tuesday_slot_2": {
+                        "name": "Dinsdag Slot 2",
+                        "state": {
+                            "not enabled": "Niet ingeschakeld",
+                            "not configured": "Niet geconfigureerd"
+                        }
+                    },
+                    "wednesday_slot_1": {
+                        "name": "Woensdag Slot 1",
+                        "state": {
+                            "not enabled": "Niet ingeschakeld",
+                            "not configured": "Niet geconfigureerd"
+                        }
+                    },
+                    "wednesday_slot_2": {
+                        "name": "Woensdag Slot 2",
+                        "state": {
+                            "not enabled": "Niet ingeschakeld",
+                            "not configured": "Niet geconfigureerd"
+                        }
+                    },
+                    "thursday_slot_1": {
+                        "name": "Donderdag Slot 1",
+                        "state": {
+                            "not enabled": "Niet ingeschakeld",
+                            "not configured": "Niet geconfigureerd"
+                        }
+                    },
+                    "thursday_slot_2": {
+                        "name": "Donderdag Slot 2",
+                        "state": {
+                            "not enabled": "Niet ingeschakeld",
+                            "not configured": "Niet geconfigureerd"
+                        }
+                    },
+                    "friday_slot_1": {
+                        "name": "Vrijdag Slot 1",
+                        "state": {
+                            "not enabled": "Niet ingeschakeld",
+                            "not configured": "Niet geconfigureerd"
+                        }
+                    },
+                    "friday_slot_2": {
+                        "name": "Vrijdag Slot 2",
+                        "state": {
+                            "not enabled": "Niet ingeschakeld",
+                            "not configured": "Niet geconfigureerd"
+                        }
+                    },
+                    "saturday_slot_1": {
+                        "name": "Zaterdag Slot 1",
+                        "state": {
+                            "not enabled": "Niet ingeschakeld",
+                            "not configured": "Niet geconfigureerd"
+                        }
+                    },
+                    "saturday_slot_2": {
+                        "name": "Zaterdag Slot 2",
+                        "state": {
+                            "not enabled": "Niet ingeschakeld",
+                            "not configured": "Niet geconfigureerd"
+                        }
+                    },
+                    "sunday_slot_1": {
+                        "name": "Zondag Slot 1",
+                        "state": {
+                            "not enabled": "Niet ingeschakeld",
+                            "not configured": "Niet geconfigureerd"
+                        }
+                    },
+                    "sunday_slot_2": {
+                        "name": "Zondag Slot 2",
+                        "state": {
+                            "not enabled": "Niet ingeschakeld",
+                            "not configured": "Niet geconfigureerd"
+                        }
+                    }
+                }
+            },
+            "predictive_calendar_slots": {
+                "name": "SmartMowing-blokkeertijden",
+                "state": {
+                    "Manual calendar active": "Handmatige kalender actief",
+                    "off": "Uit"
+                },
+                "state_attributes": {
+                    "last_updated": {
+                        "name": "Laatst bijgewerkt"
+                    },
+                    "smartmowing_enabled": {
+                        "name": "SmartMowing actief"
+                    },
+                    "mowing_mode": {
+                        "name": "Maaimodus"
+                    },
+                    "earliest_start": {
+                        "name": "Vroegste start",
+                        "state": {
+                            "not enabled": "Niet ingeschakeld"
+                        }
+                    },
+                    "latest_end": {
+                        "name": "Laatste einde",
+                        "state": {
+                            "not enabled": "Niet ingeschakeld"
+                        }
+                    },
+                    "blocked_before": {
+                        "name": "Geblokkeerd voor",
+                        "state": {
+                            "not enabled": "Niet ingeschakeld"
+                        }
+                    },
+                    "blocked_after": {
+                        "name": "Geblokkeerd na",
+                        "state": {
+                            "not enabled": "Niet ingeschakeld"
+                        }
+                    }
+                }
+            },
+            "predictive_schedule": {
+                "name": "SmartMowing-schema",
+                "state": {
+                    "Manual calendar active": "Handmatige kalender actief",
+                    "none": "Geen"
+                },
+                "state_attributes": {
+                    "last_updated": {
+                        "name": "Laatst bijgewerkt"
+                    },
+                    "next_mow_slot": {
+                        "name": "Volgend gepland maaislot",
+                        "state": {
+                            "none": "Geen"
+                        }
+                    },
+                    "next_mow_day": {
+                        "name": "Volgende geplande maaidag",
+                        "state": {
+                            "none": "Geen",
+                            "monday": "Maandag",
+                            "tuesday": "Dinsdag",
+                            "wednesday": "Woensdag",
+                            "thursday": "Donderdag",
+                            "friday": "Vrijdag",
+                            "saturday": "Zaterdag",
+                            "sunday": "Zondag"
+                        }
+                    },
+                    "next_mow_time": {
+                        "name": "Volgende geplande maaitijd",
+                        "state": {
+                            "none": "Geen"
+                        }
+                    },
+                    "schedule_monday": {
+                        "name": "Schema Maandag",
+                        "state": {
+                            "not scheduled": "Niet gepland"
+                        }
+                    },
+                    "exclusion_monday_user": {
+                        "name": "Blokkeertijd Maandag gebruiker",
+                        "state": {
+                            "none": "Geen"
+                        }
+                    },
+                    "exclusion_monday_weather": {
+                        "name": "Blokkeertijd Maandag weer",
+                        "state": {
+                            "none": "Geen"
+                        }
+                    },
+                    "schedule_tuesday": {
+                        "name": "Schema Dinsdag",
+                        "state": {
+                            "not scheduled": "Niet gepland"
+                        }
+                    },
+                    "exclusion_tuesday_user": {
+                        "name": "Blokkeertijd Dinsdag gebruiker",
+                        "state": {
+                            "none": "Geen"
+                        }
+                    },
+                    "exclusion_tuesday_weather": {
+                        "name": "Blokkeertijd Dinsdag weer",
+                        "state": {
+                            "none": "Geen"
+                        }
+                    },
+                    "schedule_wednesday": {
+                        "name": "Schema Woensdag",
+                        "state": {
+                            "not scheduled": "Niet gepland"
+                        }
+                    },
+                    "exclusion_wednesday_user": {
+                        "name": "Blokkeertijd Woensdag gebruiker",
+                        "state": {
+                            "none": "Geen"
+                        }
+                    },
+                    "exclusion_wednesday_weather": {
+                        "name": "Blokkeertijd Woensdag weer",
+                        "state": {
+                            "none": "Geen"
+                        }
+                    },
+                    "schedule_thursday": {
+                        "name": "Schema Donderdag",
+                        "state": {
+                            "not scheduled": "Niet gepland"
+                        }
+                    },
+                    "exclusion_thursday_user": {
+                        "name": "Blokkeertijd Donderdag gebruiker",
+                        "state": {
+                            "none": "Geen"
+                        }
+                    },
+                    "exclusion_thursday_weather": {
+                        "name": "Blokkeertijd Donderdag weer",
+                        "state": {
+                            "none": "Geen"
+                        }
+                    },
+                    "schedule_friday": {
+                        "name": "Schema Vrijdag",
+                        "state": {
+                            "not scheduled": "Niet gepland"
+                        }
+                    },
+                    "exclusion_friday_user": {
+                        "name": "Blokkeertijd Vrijdag gebruiker",
+                        "state": {
+                            "none": "Geen"
+                        }
+                    },
+                    "exclusion_friday_weather": {
+                        "name": "Blokkeertijd Vrijdag weer",
+                        "state": {
+                            "none": "Geen"
+                        }
+                    },
+                    "schedule_saturday": {
+                        "name": "Schema Zaterdag",
+                        "state": {
+                            "not scheduled": "Niet gepland"
+                        }
+                    },
+                    "exclusion_saturday_user": {
+                        "name": "Blokkeertijd Zaterdag gebruiker",
+                        "state": {
+                            "none": "Geen"
+                        }
+                    },
+                    "exclusion_saturday_weather": {
+                        "name": "Blokkeertijd Zaterdag weer",
+                        "state": {
+                            "none": "Geen"
+                        }
+                    },
+                    "schedule_sunday": {
+                        "name": "Schema Zondag",
+                        "state": {
+                            "not scheduled": "Niet gepland"
+                        }
+                    },
+                    "exclusion_sunday_user": {
+                        "name": "Blokkeertijd Zondag gebruiker",
+                        "state": {
+                            "none": "Geen"
+                        }
+                    },
+                    "exclusion_sunday_weather": {
+                        "name": "Blokkeertijd Zondag weer",
+                        "state": {
+                            "none": "Geen"
+                        }
+                    }
+                }
             }
         },
         "camera": {

--- a/custom_components/boschindego/translations/nl.json
+++ b/custom_components/boschindego/translations/nl.json
@@ -154,7 +154,7 @@
             "mowing_mode": {
                 "name": "Maaimode",
                 "state": {
-                    "Calendar": "Handmatige kalender"
+                    "calendar": "Handmatige kalender"
                 }
             },
             "runtime_total": {
@@ -198,7 +198,7 @@
             },
             "calendar_slots": {
                 "state": {
-                    "smartmowing active": "SmartMowing actief",
+                    "smartmowing_active": "SmartMowing actief",
                     "off": "Uit"
                 },
                 "name": "Geplande maaitijden",
@@ -206,113 +206,113 @@
                     "today_slot_1": {
                         "name": "Vandaag slot 1",
                         "state": {
-                            "not enabled": "Niet ingeschakeld",
-                            "not configured": "Niet geconfigureerd"
+                            "not_enabled": "Niet ingeschakeld",
+                            "not_configured": "Niet geconfigureerd"
                         }
                     },
                     "today_slot_2": {
                         "name": "Vandaag slot 2",
                         "state": {
-                            "not enabled": "Niet ingeschakeld",
-                            "not configured": "Niet geconfigureerd"
+                            "not_enabled": "Niet ingeschakeld",
+                            "not_configured": "Niet geconfigureerd"
                         }
                     },
                     "monday_slot_1": {
                         "name": "Maandag Slot 1",
                         "state": {
-                            "not enabled": "Niet ingeschakeld",
-                            "not configured": "Niet geconfigureerd"
+                            "not_enabled": "Niet ingeschakeld",
+                            "not_configured": "Niet geconfigureerd"
                         }
                     },
                     "monday_slot_2": {
                         "name": "Maandag Slot 2",
                         "state": {
-                            "not enabled": "Niet ingeschakeld",
-                            "not configured": "Niet geconfigureerd"
+                            "not_enabled": "Niet ingeschakeld",
+                            "not_configured": "Niet geconfigureerd"
                         }
                     },
                     "tuesday_slot_1": {
                         "name": "Dinsdag Slot 1",
                         "state": {
-                            "not enabled": "Niet ingeschakeld",
-                            "not configured": "Niet geconfigureerd"
+                            "not_enabled": "Niet ingeschakeld",
+                            "not_configured": "Niet geconfigureerd"
                         }
                     },
                     "tuesday_slot_2": {
                         "name": "Dinsdag Slot 2",
                         "state": {
-                            "not enabled": "Niet ingeschakeld",
-                            "not configured": "Niet geconfigureerd"
+                            "not_enabled": "Niet ingeschakeld",
+                            "not_configured": "Niet geconfigureerd"
                         }
                     },
                     "wednesday_slot_1": {
                         "name": "Woensdag Slot 1",
                         "state": {
-                            "not enabled": "Niet ingeschakeld",
-                            "not configured": "Niet geconfigureerd"
+                            "not_enabled": "Niet ingeschakeld",
+                            "not_configured": "Niet geconfigureerd"
                         }
                     },
                     "wednesday_slot_2": {
                         "name": "Woensdag Slot 2",
                         "state": {
-                            "not enabled": "Niet ingeschakeld",
-                            "not configured": "Niet geconfigureerd"
+                            "not_enabled": "Niet ingeschakeld",
+                            "not_configured": "Niet geconfigureerd"
                         }
                     },
                     "thursday_slot_1": {
                         "name": "Donderdag Slot 1",
                         "state": {
-                            "not enabled": "Niet ingeschakeld",
-                            "not configured": "Niet geconfigureerd"
+                            "not_enabled": "Niet ingeschakeld",
+                            "not_configured": "Niet geconfigureerd"
                         }
                     },
                     "thursday_slot_2": {
                         "name": "Donderdag Slot 2",
                         "state": {
-                            "not enabled": "Niet ingeschakeld",
-                            "not configured": "Niet geconfigureerd"
+                            "not_enabled": "Niet ingeschakeld",
+                            "not_configured": "Niet geconfigureerd"
                         }
                     },
                     "friday_slot_1": {
                         "name": "Vrijdag Slot 1",
                         "state": {
-                            "not enabled": "Niet ingeschakeld",
-                            "not configured": "Niet geconfigureerd"
+                            "not_enabled": "Niet ingeschakeld",
+                            "not_configured": "Niet geconfigureerd"
                         }
                     },
                     "friday_slot_2": {
                         "name": "Vrijdag Slot 2",
                         "state": {
-                            "not enabled": "Niet ingeschakeld",
-                            "not configured": "Niet geconfigureerd"
+                            "not_enabled": "Niet ingeschakeld",
+                            "not_configured": "Niet geconfigureerd"
                         }
                     },
                     "saturday_slot_1": {
                         "name": "Zaterdag Slot 1",
                         "state": {
-                            "not enabled": "Niet ingeschakeld",
-                            "not configured": "Niet geconfigureerd"
+                            "not_enabled": "Niet ingeschakeld",
+                            "not_configured": "Niet geconfigureerd"
                         }
                     },
                     "saturday_slot_2": {
                         "name": "Zaterdag Slot 2",
                         "state": {
-                            "not enabled": "Niet ingeschakeld",
-                            "not configured": "Niet geconfigureerd"
+                            "not_enabled": "Niet ingeschakeld",
+                            "not_configured": "Niet geconfigureerd"
                         }
                     },
                     "sunday_slot_1": {
                         "name": "Zondag Slot 1",
                         "state": {
-                            "not enabled": "Niet ingeschakeld",
-                            "not configured": "Niet geconfigureerd"
+                            "not_enabled": "Niet ingeschakeld",
+                            "not_configured": "Niet geconfigureerd"
                         }
                     },
                     "sunday_slot_2": {
                         "name": "Zondag Slot 2",
                         "state": {
-                            "not enabled": "Niet ingeschakeld",
-                            "not configured": "Niet geconfigureerd"
+                            "not_enabled": "Niet ingeschakeld",
+                            "not_configured": "Niet geconfigureerd"
                         }
                     }
                 }
@@ -320,7 +320,7 @@
             "predictive_calendar_slots": {
                 "name": "SmartMowing-blokkeertijden",
                 "state": {
-                    "manual calendar active": "Handmatige kalender actief",
+                    "manual_calendar_active": "Handmatige kalender actief",
                     "off": "Uit"
                 },
                 "state_attributes": {
@@ -336,25 +336,25 @@
                     "earliest_start": {
                         "name": "Vroegste start",
                         "state": {
-                            "not enabled": "Niet ingeschakeld"
+                            "not_enabled": "Niet ingeschakeld"
                         }
                     },
                     "latest_end": {
                         "name": "Laatste einde",
                         "state": {
-                            "not enabled": "Niet ingeschakeld"
+                            "not_enabled": "Niet ingeschakeld"
                         }
                     },
                     "blocked_before": {
                         "name": "Geblokkeerd voor",
                         "state": {
-                            "not enabled": "Niet ingeschakeld"
+                            "not_enabled": "Niet ingeschakeld"
                         }
                     },
                     "blocked_after": {
                         "name": "Geblokkeerd na",
                         "state": {
-                            "not enabled": "Niet ingeschakeld"
+                            "not_enabled": "Niet ingeschakeld"
                         }
                     }
                 }
@@ -362,7 +362,7 @@
             "predictive_schedule": {
                 "name": "SmartMowing-schema",
                 "state": {
-                    "manual calendar active": "Handmatige kalender actief",
+                    "manual_calendar_active": "Handmatige kalender actief",
                     "none": "Geen"
                 },
                 "state_attributes": {
@@ -397,7 +397,7 @@
                     "schedule_monday": {
                         "name": "Schema Maandag",
                         "state": {
-                            "not scheduled": "Niet gepland"
+                            "not_scheduled": "Niet gepland"
                         }
                     },
                     "exclusion_monday_user": {
@@ -415,7 +415,7 @@
                     "schedule_tuesday": {
                         "name": "Schema Dinsdag",
                         "state": {
-                            "not scheduled": "Niet gepland"
+                            "not_scheduled": "Niet gepland"
                         }
                     },
                     "exclusion_tuesday_user": {
@@ -433,7 +433,7 @@
                     "schedule_wednesday": {
                         "name": "Schema Woensdag",
                         "state": {
-                            "not scheduled": "Niet gepland"
+                            "not_scheduled": "Niet gepland"
                         }
                     },
                     "exclusion_wednesday_user": {
@@ -451,7 +451,7 @@
                     "schedule_thursday": {
                         "name": "Schema Donderdag",
                         "state": {
-                            "not scheduled": "Niet gepland"
+                            "not_scheduled": "Niet gepland"
                         }
                     },
                     "exclusion_thursday_user": {
@@ -469,7 +469,7 @@
                     "schedule_friday": {
                         "name": "Schema Vrijdag",
                         "state": {
-                            "not scheduled": "Niet gepland"
+                            "not_scheduled": "Niet gepland"
                         }
                     },
                     "exclusion_friday_user": {
@@ -487,7 +487,7 @@
                     "schedule_saturday": {
                         "name": "Schema Zaterdag",
                         "state": {
-                            "not scheduled": "Niet gepland"
+                            "not_scheduled": "Niet gepland"
                         }
                     },
                     "exclusion_saturday_user": {
@@ -505,7 +505,7 @@
                     "schedule_sunday": {
                         "name": "Schema Zondag",
                         "state": {
-                            "not scheduled": "Niet gepland"
+                            "not_scheduled": "Niet gepland"
                         }
                     },
                     "exclusion_sunday_user": {

--- a/custom_components/boschindego/translations/no.json
+++ b/custom_components/boschindego/translations/no.json
@@ -152,7 +152,10 @@
                 "name": "Neste klipping"
             },
             "mowing_mode": {
-                "name": "Klippemodus"
+                "name": "Klippemodus",
+                "state": {
+                    "Calendar": "Manuell kalender"
+                }
             },
             "runtime_total": {
                 "name": "Total klippetid"
@@ -192,6 +195,332 @@
             },
             "battery_discharge": {
                 "name": "Batteriutladning"
+            },
+            "calendar_slots": {
+                "state": {
+                    "SmartMowing active": "SmartMowing aktiv",
+                    "off": "Av"
+                },
+                "name": "Planlagte klippetider",
+                "state_attributes": {
+                    "today_slot_1": {
+                        "name": "I dag tidsrom 1",
+                        "state": {
+                            "not enabled": "Ikke aktivert",
+                            "not configured": "Ikke konfigurert"
+                        }
+                    },
+                    "today_slot_2": {
+                        "name": "I dag tidsrom 2",
+                        "state": {
+                            "not enabled": "Ikke aktivert",
+                            "not configured": "Ikke konfigurert"
+                        }
+                    },
+                    "monday_slot_1": {
+                        "name": "Mandag Slot 1",
+                        "state": {
+                            "not enabled": "Ikke aktivert",
+                            "not configured": "Ikke konfigurert"
+                        }
+                    },
+                    "monday_slot_2": {
+                        "name": "Mandag Slot 2",
+                        "state": {
+                            "not enabled": "Ikke aktivert",
+                            "not configured": "Ikke konfigurert"
+                        }
+                    },
+                    "tuesday_slot_1": {
+                        "name": "Tirsdag Slot 1",
+                        "state": {
+                            "not enabled": "Ikke aktivert",
+                            "not configured": "Ikke konfigurert"
+                        }
+                    },
+                    "tuesday_slot_2": {
+                        "name": "Tirsdag Slot 2",
+                        "state": {
+                            "not enabled": "Ikke aktivert",
+                            "not configured": "Ikke konfigurert"
+                        }
+                    },
+                    "wednesday_slot_1": {
+                        "name": "Onsdag Slot 1",
+                        "state": {
+                            "not enabled": "Ikke aktivert",
+                            "not configured": "Ikke konfigurert"
+                        }
+                    },
+                    "wednesday_slot_2": {
+                        "name": "Onsdag Slot 2",
+                        "state": {
+                            "not enabled": "Ikke aktivert",
+                            "not configured": "Ikke konfigurert"
+                        }
+                    },
+                    "thursday_slot_1": {
+                        "name": "Torsdag Slot 1",
+                        "state": {
+                            "not enabled": "Ikke aktivert",
+                            "not configured": "Ikke konfigurert"
+                        }
+                    },
+                    "thursday_slot_2": {
+                        "name": "Torsdag Slot 2",
+                        "state": {
+                            "not enabled": "Ikke aktivert",
+                            "not configured": "Ikke konfigurert"
+                        }
+                    },
+                    "friday_slot_1": {
+                        "name": "Fredag Slot 1",
+                        "state": {
+                            "not enabled": "Ikke aktivert",
+                            "not configured": "Ikke konfigurert"
+                        }
+                    },
+                    "friday_slot_2": {
+                        "name": "Fredag Slot 2",
+                        "state": {
+                            "not enabled": "Ikke aktivert",
+                            "not configured": "Ikke konfigurert"
+                        }
+                    },
+                    "saturday_slot_1": {
+                        "name": "Lørdag Slot 1",
+                        "state": {
+                            "not enabled": "Ikke aktivert",
+                            "not configured": "Ikke konfigurert"
+                        }
+                    },
+                    "saturday_slot_2": {
+                        "name": "Lørdag Slot 2",
+                        "state": {
+                            "not enabled": "Ikke aktivert",
+                            "not configured": "Ikke konfigurert"
+                        }
+                    },
+                    "sunday_slot_1": {
+                        "name": "Søndag Slot 1",
+                        "state": {
+                            "not enabled": "Ikke aktivert",
+                            "not configured": "Ikke konfigurert"
+                        }
+                    },
+                    "sunday_slot_2": {
+                        "name": "Søndag Slot 2",
+                        "state": {
+                            "not enabled": "Ikke aktivert",
+                            "not configured": "Ikke konfigurert"
+                        }
+                    }
+                }
+            },
+            "predictive_calendar_slots": {
+                "name": "SmartMowing-blokkerte tider",
+                "state": {
+                    "Manual calendar active": "Manuell kalender aktiv",
+                    "off": "Av"
+                },
+                "state_attributes": {
+                    "last_updated": {
+                        "name": "Sist oppdatert"
+                    },
+                    "smartmowing_enabled": {
+                        "name": "SmartMowing aktiv"
+                    },
+                    "mowing_mode": {
+                        "name": "Klippemodus"
+                    },
+                    "earliest_start": {
+                        "name": "Tidligste start",
+                        "state": {
+                            "not enabled": "Ikke aktivert"
+                        }
+                    },
+                    "latest_end": {
+                        "name": "Seneste slutt",
+                        "state": {
+                            "not enabled": "Ikke aktivert"
+                        }
+                    },
+                    "blocked_before": {
+                        "name": "Blokkert før",
+                        "state": {
+                            "not enabled": "Ikke aktivert"
+                        }
+                    },
+                    "blocked_after": {
+                        "name": "Blokkert etter",
+                        "state": {
+                            "not enabled": "Ikke aktivert"
+                        }
+                    }
+                }
+            },
+            "predictive_schedule": {
+                "name": "SmartMowing-tidsplan",
+                "state": {
+                    "Manual calendar active": "Manuell kalender aktiv",
+                    "none": "Ingen"
+                },
+                "state_attributes": {
+                    "last_updated": {
+                        "name": "Sist oppdatert"
+                    },
+                    "next_mow_slot": {
+                        "name": "Neste planlagte klippetidsrom",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "next_mow_day": {
+                        "name": "Neste planlagte klippedag",
+                        "state": {
+                            "none": "Ingen",
+                            "monday": "Mandag",
+                            "tuesday": "Tirsdag",
+                            "wednesday": "Onsdag",
+                            "thursday": "Torsdag",
+                            "friday": "Fredag",
+                            "saturday": "Lørdag",
+                            "sunday": "Søndag"
+                        }
+                    },
+                    "next_mow_time": {
+                        "name": "Neste planlagte klippetid",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "schedule_monday": {
+                        "name": "Tidsplan Mandag",
+                        "state": {
+                            "not scheduled": "Ikke planlagt"
+                        }
+                    },
+                    "exclusion_monday_user": {
+                        "name": "Blokkert tid Mandag bruker",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "exclusion_monday_weather": {
+                        "name": "Blokkert tid Mandag vær",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "schedule_tuesday": {
+                        "name": "Tidsplan Tirsdag",
+                        "state": {
+                            "not scheduled": "Ikke planlagt"
+                        }
+                    },
+                    "exclusion_tuesday_user": {
+                        "name": "Blokkert tid Tirsdag bruker",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "exclusion_tuesday_weather": {
+                        "name": "Blokkert tid Tirsdag vær",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "schedule_wednesday": {
+                        "name": "Tidsplan Onsdag",
+                        "state": {
+                            "not scheduled": "Ikke planlagt"
+                        }
+                    },
+                    "exclusion_wednesday_user": {
+                        "name": "Blokkert tid Onsdag bruker",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "exclusion_wednesday_weather": {
+                        "name": "Blokkert tid Onsdag vær",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "schedule_thursday": {
+                        "name": "Tidsplan Torsdag",
+                        "state": {
+                            "not scheduled": "Ikke planlagt"
+                        }
+                    },
+                    "exclusion_thursday_user": {
+                        "name": "Blokkert tid Torsdag bruker",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "exclusion_thursday_weather": {
+                        "name": "Blokkert tid Torsdag vær",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "schedule_friday": {
+                        "name": "Tidsplan Fredag",
+                        "state": {
+                            "not scheduled": "Ikke planlagt"
+                        }
+                    },
+                    "exclusion_friday_user": {
+                        "name": "Blokkert tid Fredag bruker",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "exclusion_friday_weather": {
+                        "name": "Blokkert tid Fredag vær",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "schedule_saturday": {
+                        "name": "Tidsplan Lørdag",
+                        "state": {
+                            "not scheduled": "Ikke planlagt"
+                        }
+                    },
+                    "exclusion_saturday_user": {
+                        "name": "Blokkert tid Lørdag bruker",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "exclusion_saturday_weather": {
+                        "name": "Blokkert tid Lørdag vær",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "schedule_sunday": {
+                        "name": "Tidsplan Søndag",
+                        "state": {
+                            "not scheduled": "Ikke planlagt"
+                        }
+                    },
+                    "exclusion_sunday_user": {
+                        "name": "Blokkert tid Søndag bruker",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "exclusion_sunday_weather": {
+                        "name": "Blokkert tid Søndag vær",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    }
+                }
             }
         },
         "camera": {

--- a/custom_components/boschindego/translations/no.json
+++ b/custom_components/boschindego/translations/no.json
@@ -154,7 +154,7 @@
             "mowing_mode": {
                 "name": "Klippemodus",
                 "state": {
-                    "Calendar": "Manuell kalender"
+                    "calendar": "Manuell kalender"
                 }
             },
             "runtime_total": {
@@ -198,7 +198,7 @@
             },
             "calendar_slots": {
                 "state": {
-                    "smartmowing active": "SmartMowing aktiv",
+                    "smartmowing_active": "SmartMowing aktiv",
                     "off": "Av"
                 },
                 "name": "Planlagte klippetider",
@@ -206,113 +206,113 @@
                     "today_slot_1": {
                         "name": "I dag tidsrom 1",
                         "state": {
-                            "not enabled": "Ikke aktivert",
-                            "not configured": "Ikke konfigurert"
+                            "not_enabled": "Ikke aktivert",
+                            "not_configured": "Ikke konfigurert"
                         }
                     },
                     "today_slot_2": {
                         "name": "I dag tidsrom 2",
                         "state": {
-                            "not enabled": "Ikke aktivert",
-                            "not configured": "Ikke konfigurert"
+                            "not_enabled": "Ikke aktivert",
+                            "not_configured": "Ikke konfigurert"
                         }
                     },
                     "monday_slot_1": {
                         "name": "Mandag Slot 1",
                         "state": {
-                            "not enabled": "Ikke aktivert",
-                            "not configured": "Ikke konfigurert"
+                            "not_enabled": "Ikke aktivert",
+                            "not_configured": "Ikke konfigurert"
                         }
                     },
                     "monday_slot_2": {
                         "name": "Mandag Slot 2",
                         "state": {
-                            "not enabled": "Ikke aktivert",
-                            "not configured": "Ikke konfigurert"
+                            "not_enabled": "Ikke aktivert",
+                            "not_configured": "Ikke konfigurert"
                         }
                     },
                     "tuesday_slot_1": {
                         "name": "Tirsdag Slot 1",
                         "state": {
-                            "not enabled": "Ikke aktivert",
-                            "not configured": "Ikke konfigurert"
+                            "not_enabled": "Ikke aktivert",
+                            "not_configured": "Ikke konfigurert"
                         }
                     },
                     "tuesday_slot_2": {
                         "name": "Tirsdag Slot 2",
                         "state": {
-                            "not enabled": "Ikke aktivert",
-                            "not configured": "Ikke konfigurert"
+                            "not_enabled": "Ikke aktivert",
+                            "not_configured": "Ikke konfigurert"
                         }
                     },
                     "wednesday_slot_1": {
                         "name": "Onsdag Slot 1",
                         "state": {
-                            "not enabled": "Ikke aktivert",
-                            "not configured": "Ikke konfigurert"
+                            "not_enabled": "Ikke aktivert",
+                            "not_configured": "Ikke konfigurert"
                         }
                     },
                     "wednesday_slot_2": {
                         "name": "Onsdag Slot 2",
                         "state": {
-                            "not enabled": "Ikke aktivert",
-                            "not configured": "Ikke konfigurert"
+                            "not_enabled": "Ikke aktivert",
+                            "not_configured": "Ikke konfigurert"
                         }
                     },
                     "thursday_slot_1": {
                         "name": "Torsdag Slot 1",
                         "state": {
-                            "not enabled": "Ikke aktivert",
-                            "not configured": "Ikke konfigurert"
+                            "not_enabled": "Ikke aktivert",
+                            "not_configured": "Ikke konfigurert"
                         }
                     },
                     "thursday_slot_2": {
                         "name": "Torsdag Slot 2",
                         "state": {
-                            "not enabled": "Ikke aktivert",
-                            "not configured": "Ikke konfigurert"
+                            "not_enabled": "Ikke aktivert",
+                            "not_configured": "Ikke konfigurert"
                         }
                     },
                     "friday_slot_1": {
                         "name": "Fredag Slot 1",
                         "state": {
-                            "not enabled": "Ikke aktivert",
-                            "not configured": "Ikke konfigurert"
+                            "not_enabled": "Ikke aktivert",
+                            "not_configured": "Ikke konfigurert"
                         }
                     },
                     "friday_slot_2": {
                         "name": "Fredag Slot 2",
                         "state": {
-                            "not enabled": "Ikke aktivert",
-                            "not configured": "Ikke konfigurert"
+                            "not_enabled": "Ikke aktivert",
+                            "not_configured": "Ikke konfigurert"
                         }
                     },
                     "saturday_slot_1": {
                         "name": "Lørdag Slot 1",
                         "state": {
-                            "not enabled": "Ikke aktivert",
-                            "not configured": "Ikke konfigurert"
+                            "not_enabled": "Ikke aktivert",
+                            "not_configured": "Ikke konfigurert"
                         }
                     },
                     "saturday_slot_2": {
                         "name": "Lørdag Slot 2",
                         "state": {
-                            "not enabled": "Ikke aktivert",
-                            "not configured": "Ikke konfigurert"
+                            "not_enabled": "Ikke aktivert",
+                            "not_configured": "Ikke konfigurert"
                         }
                     },
                     "sunday_slot_1": {
                         "name": "Søndag Slot 1",
                         "state": {
-                            "not enabled": "Ikke aktivert",
-                            "not configured": "Ikke konfigurert"
+                            "not_enabled": "Ikke aktivert",
+                            "not_configured": "Ikke konfigurert"
                         }
                     },
                     "sunday_slot_2": {
                         "name": "Søndag Slot 2",
                         "state": {
-                            "not enabled": "Ikke aktivert",
-                            "not configured": "Ikke konfigurert"
+                            "not_enabled": "Ikke aktivert",
+                            "not_configured": "Ikke konfigurert"
                         }
                     }
                 }
@@ -320,7 +320,7 @@
             "predictive_calendar_slots": {
                 "name": "SmartMowing-blokkerte tider",
                 "state": {
-                    "manual calendar active": "Manuell kalender aktiv",
+                    "manual_calendar_active": "Manuell kalender aktiv",
                     "off": "Av"
                 },
                 "state_attributes": {
@@ -336,25 +336,25 @@
                     "earliest_start": {
                         "name": "Tidligste start",
                         "state": {
-                            "not enabled": "Ikke aktivert"
+                            "not_enabled": "Ikke aktivert"
                         }
                     },
                     "latest_end": {
                         "name": "Seneste slutt",
                         "state": {
-                            "not enabled": "Ikke aktivert"
+                            "not_enabled": "Ikke aktivert"
                         }
                     },
                     "blocked_before": {
                         "name": "Blokkert før",
                         "state": {
-                            "not enabled": "Ikke aktivert"
+                            "not_enabled": "Ikke aktivert"
                         }
                     },
                     "blocked_after": {
                         "name": "Blokkert etter",
                         "state": {
-                            "not enabled": "Ikke aktivert"
+                            "not_enabled": "Ikke aktivert"
                         }
                     }
                 }
@@ -362,7 +362,7 @@
             "predictive_schedule": {
                 "name": "SmartMowing-tidsplan",
                 "state": {
-                    "manual calendar active": "Manuell kalender aktiv",
+                    "manual_calendar_active": "Manuell kalender aktiv",
                     "none": "Ingen"
                 },
                 "state_attributes": {
@@ -397,7 +397,7 @@
                     "schedule_monday": {
                         "name": "Tidsplan Mandag",
                         "state": {
-                            "not scheduled": "Ikke planlagt"
+                            "not_scheduled": "Ikke planlagt"
                         }
                     },
                     "exclusion_monday_user": {
@@ -415,7 +415,7 @@
                     "schedule_tuesday": {
                         "name": "Tidsplan Tirsdag",
                         "state": {
-                            "not scheduled": "Ikke planlagt"
+                            "not_scheduled": "Ikke planlagt"
                         }
                     },
                     "exclusion_tuesday_user": {
@@ -433,7 +433,7 @@
                     "schedule_wednesday": {
                         "name": "Tidsplan Onsdag",
                         "state": {
-                            "not scheduled": "Ikke planlagt"
+                            "not_scheduled": "Ikke planlagt"
                         }
                     },
                     "exclusion_wednesday_user": {
@@ -451,7 +451,7 @@
                     "schedule_thursday": {
                         "name": "Tidsplan Torsdag",
                         "state": {
-                            "not scheduled": "Ikke planlagt"
+                            "not_scheduled": "Ikke planlagt"
                         }
                     },
                     "exclusion_thursday_user": {
@@ -469,7 +469,7 @@
                     "schedule_friday": {
                         "name": "Tidsplan Fredag",
                         "state": {
-                            "not scheduled": "Ikke planlagt"
+                            "not_scheduled": "Ikke planlagt"
                         }
                     },
                     "exclusion_friday_user": {
@@ -487,7 +487,7 @@
                     "schedule_saturday": {
                         "name": "Tidsplan Lørdag",
                         "state": {
-                            "not scheduled": "Ikke planlagt"
+                            "not_scheduled": "Ikke planlagt"
                         }
                     },
                     "exclusion_saturday_user": {
@@ -505,7 +505,7 @@
                     "schedule_sunday": {
                         "name": "Tidsplan Søndag",
                         "state": {
-                            "not scheduled": "Ikke planlagt"
+                            "not_scheduled": "Ikke planlagt"
                         }
                     },
                     "exclusion_sunday_user": {

--- a/custom_components/boschindego/translations/no.json
+++ b/custom_components/boschindego/translations/no.json
@@ -198,7 +198,7 @@
             },
             "calendar_slots": {
                 "state": {
-                    "SmartMowing active": "SmartMowing aktiv",
+                    "smartmowing active": "SmartMowing aktiv",
                     "off": "Av"
                 },
                 "name": "Planlagte klippetider",
@@ -320,7 +320,7 @@
             "predictive_calendar_slots": {
                 "name": "SmartMowing-blokkerte tider",
                 "state": {
-                    "Manual calendar active": "Manuell kalender aktiv",
+                    "manual calendar active": "Manuell kalender aktiv",
                     "off": "Av"
                 },
                 "state_attributes": {
@@ -362,7 +362,7 @@
             "predictive_schedule": {
                 "name": "SmartMowing-tidsplan",
                 "state": {
-                    "Manual calendar active": "Manuell kalender aktiv",
+                    "manual calendar active": "Manuell kalender aktiv",
                     "none": "Ingen"
                 },
                 "state_attributes": {

--- a/custom_components/boschindego/translations/pl.json
+++ b/custom_components/boschindego/translations/pl.json
@@ -154,7 +154,7 @@
             "mowing_mode": {
                 "name": "Tryb koszenia",
                 "state": {
-                    "Calendar": "Kalendarz ręczny"
+                    "calendar": "Kalendarz ręczny"
                 }
             },
             "runtime_total": {
@@ -198,7 +198,7 @@
             },
             "calendar_slots": {
                 "state": {
-                    "smartmowing active": "SmartMowing aktywny",
+                    "smartmowing_active": "SmartMowing aktywny",
                     "off": "Wyłączone"
                 },
                 "name": "Zaplanowane czasy koszenia",
@@ -206,113 +206,113 @@
                     "today_slot_1": {
                         "name": "Dzisiejszy przedział 1",
                         "state": {
-                            "not enabled": "Nieaktywny",
-                            "not configured": "Nie skonfigurowano"
+                            "not_enabled": "Nieaktywny",
+                            "not_configured": "Nie skonfigurowano"
                         }
                     },
                     "today_slot_2": {
                         "name": "Dzisiejszy przedział 2",
                         "state": {
-                            "not enabled": "Nieaktywny",
-                            "not configured": "Nie skonfigurowano"
+                            "not_enabled": "Nieaktywny",
+                            "not_configured": "Nie skonfigurowano"
                         }
                     },
                     "monday_slot_1": {
                         "name": "Poniedziałek Slot 1",
                         "state": {
-                            "not enabled": "Nieaktywny",
-                            "not configured": "Nie skonfigurowano"
+                            "not_enabled": "Nieaktywny",
+                            "not_configured": "Nie skonfigurowano"
                         }
                     },
                     "monday_slot_2": {
                         "name": "Poniedziałek Slot 2",
                         "state": {
-                            "not enabled": "Nieaktywny",
-                            "not configured": "Nie skonfigurowano"
+                            "not_enabled": "Nieaktywny",
+                            "not_configured": "Nie skonfigurowano"
                         }
                     },
                     "tuesday_slot_1": {
                         "name": "Wtorek Slot 1",
                         "state": {
-                            "not enabled": "Nieaktywny",
-                            "not configured": "Nie skonfigurowano"
+                            "not_enabled": "Nieaktywny",
+                            "not_configured": "Nie skonfigurowano"
                         }
                     },
                     "tuesday_slot_2": {
                         "name": "Wtorek Slot 2",
                         "state": {
-                            "not enabled": "Nieaktywny",
-                            "not configured": "Nie skonfigurowano"
+                            "not_enabled": "Nieaktywny",
+                            "not_configured": "Nie skonfigurowano"
                         }
                     },
                     "wednesday_slot_1": {
                         "name": "Środa Slot 1",
                         "state": {
-                            "not enabled": "Nieaktywny",
-                            "not configured": "Nie skonfigurowano"
+                            "not_enabled": "Nieaktywny",
+                            "not_configured": "Nie skonfigurowano"
                         }
                     },
                     "wednesday_slot_2": {
                         "name": "Środa Slot 2",
                         "state": {
-                            "not enabled": "Nieaktywny",
-                            "not configured": "Nie skonfigurowano"
+                            "not_enabled": "Nieaktywny",
+                            "not_configured": "Nie skonfigurowano"
                         }
                     },
                     "thursday_slot_1": {
                         "name": "Czwartek Slot 1",
                         "state": {
-                            "not enabled": "Nieaktywny",
-                            "not configured": "Nie skonfigurowano"
+                            "not_enabled": "Nieaktywny",
+                            "not_configured": "Nie skonfigurowano"
                         }
                     },
                     "thursday_slot_2": {
                         "name": "Czwartek Slot 2",
                         "state": {
-                            "not enabled": "Nieaktywny",
-                            "not configured": "Nie skonfigurowano"
+                            "not_enabled": "Nieaktywny",
+                            "not_configured": "Nie skonfigurowano"
                         }
                     },
                     "friday_slot_1": {
                         "name": "Piątek Slot 1",
                         "state": {
-                            "not enabled": "Nieaktywny",
-                            "not configured": "Nie skonfigurowano"
+                            "not_enabled": "Nieaktywny",
+                            "not_configured": "Nie skonfigurowano"
                         }
                     },
                     "friday_slot_2": {
                         "name": "Piątek Slot 2",
                         "state": {
-                            "not enabled": "Nieaktywny",
-                            "not configured": "Nie skonfigurowano"
+                            "not_enabled": "Nieaktywny",
+                            "not_configured": "Nie skonfigurowano"
                         }
                     },
                     "saturday_slot_1": {
                         "name": "Sobota Slot 1",
                         "state": {
-                            "not enabled": "Nieaktywny",
-                            "not configured": "Nie skonfigurowano"
+                            "not_enabled": "Nieaktywny",
+                            "not_configured": "Nie skonfigurowano"
                         }
                     },
                     "saturday_slot_2": {
                         "name": "Sobota Slot 2",
                         "state": {
-                            "not enabled": "Nieaktywny",
-                            "not configured": "Nie skonfigurowano"
+                            "not_enabled": "Nieaktywny",
+                            "not_configured": "Nie skonfigurowano"
                         }
                     },
                     "sunday_slot_1": {
                         "name": "Niedziela Slot 1",
                         "state": {
-                            "not enabled": "Nieaktywny",
-                            "not configured": "Nie skonfigurowano"
+                            "not_enabled": "Nieaktywny",
+                            "not_configured": "Nie skonfigurowano"
                         }
                     },
                     "sunday_slot_2": {
                         "name": "Niedziela Slot 2",
                         "state": {
-                            "not enabled": "Nieaktywny",
-                            "not configured": "Nie skonfigurowano"
+                            "not_enabled": "Nieaktywny",
+                            "not_configured": "Nie skonfigurowano"
                         }
                     }
                 }
@@ -320,7 +320,7 @@
             "predictive_calendar_slots": {
                 "name": "Okresy blokady SmartMowing",
                 "state": {
-                    "manual calendar active": "Aktywny kalendarz ręczny",
+                    "manual_calendar_active": "Aktywny kalendarz ręczny",
                     "off": "Wyłączone"
                 },
                 "state_attributes": {
@@ -336,25 +336,25 @@
                     "earliest_start": {
                         "name": "Najwcześniejszy start",
                         "state": {
-                            "not enabled": "Nieaktywny"
+                            "not_enabled": "Nieaktywny"
                         }
                     },
                     "latest_end": {
                         "name": "Najpóźniejsze zakończenie",
                         "state": {
-                            "not enabled": "Nieaktywny"
+                            "not_enabled": "Nieaktywny"
                         }
                     },
                     "blocked_before": {
                         "name": "Zablokowane przed",
                         "state": {
-                            "not enabled": "Nieaktywny"
+                            "not_enabled": "Nieaktywny"
                         }
                     },
                     "blocked_after": {
                         "name": "Zablokowane po",
                         "state": {
-                            "not enabled": "Nieaktywny"
+                            "not_enabled": "Nieaktywny"
                         }
                     }
                 }
@@ -362,7 +362,7 @@
             "predictive_schedule": {
                 "name": "Harmonogram SmartMowing",
                 "state": {
-                    "manual calendar active": "Aktywny kalendarz ręczny",
+                    "manual_calendar_active": "Aktywny kalendarz ręczny",
                     "none": "Brak"
                 },
                 "state_attributes": {
@@ -397,7 +397,7 @@
                     "schedule_monday": {
                         "name": "Harmonogram Poniedziałek",
                         "state": {
-                            "not scheduled": "Nie zaplanowano"
+                            "not_scheduled": "Nie zaplanowano"
                         }
                     },
                     "exclusion_monday_user": {
@@ -415,7 +415,7 @@
                     "schedule_tuesday": {
                         "name": "Harmonogram Wtorek",
                         "state": {
-                            "not scheduled": "Nie zaplanowano"
+                            "not_scheduled": "Nie zaplanowano"
                         }
                     },
                     "exclusion_tuesday_user": {
@@ -433,7 +433,7 @@
                     "schedule_wednesday": {
                         "name": "Harmonogram Środa",
                         "state": {
-                            "not scheduled": "Nie zaplanowano"
+                            "not_scheduled": "Nie zaplanowano"
                         }
                     },
                     "exclusion_wednesday_user": {
@@ -451,7 +451,7 @@
                     "schedule_thursday": {
                         "name": "Harmonogram Czwartek",
                         "state": {
-                            "not scheduled": "Nie zaplanowano"
+                            "not_scheduled": "Nie zaplanowano"
                         }
                     },
                     "exclusion_thursday_user": {
@@ -469,7 +469,7 @@
                     "schedule_friday": {
                         "name": "Harmonogram Piątek",
                         "state": {
-                            "not scheduled": "Nie zaplanowano"
+                            "not_scheduled": "Nie zaplanowano"
                         }
                     },
                     "exclusion_friday_user": {
@@ -487,7 +487,7 @@
                     "schedule_saturday": {
                         "name": "Harmonogram Sobota",
                         "state": {
-                            "not scheduled": "Nie zaplanowano"
+                            "not_scheduled": "Nie zaplanowano"
                         }
                     },
                     "exclusion_saturday_user": {
@@ -505,7 +505,7 @@
                     "schedule_sunday": {
                         "name": "Harmonogram Niedziela",
                         "state": {
-                            "not scheduled": "Nie zaplanowano"
+                            "not_scheduled": "Nie zaplanowano"
                         }
                     },
                     "exclusion_sunday_user": {

--- a/custom_components/boschindego/translations/pl.json
+++ b/custom_components/boschindego/translations/pl.json
@@ -198,7 +198,7 @@
             },
             "calendar_slots": {
                 "state": {
-                    "SmartMowing active": "SmartMowing aktywny",
+                    "smartmowing active": "SmartMowing aktywny",
                     "off": "Wyłączone"
                 },
                 "name": "Zaplanowane czasy koszenia",
@@ -320,7 +320,7 @@
             "predictive_calendar_slots": {
                 "name": "Okresy blokady SmartMowing",
                 "state": {
-                    "Manual calendar active": "Aktywny kalendarz ręczny",
+                    "manual calendar active": "Aktywny kalendarz ręczny",
                     "off": "Wyłączone"
                 },
                 "state_attributes": {
@@ -362,7 +362,7 @@
             "predictive_schedule": {
                 "name": "Harmonogram SmartMowing",
                 "state": {
-                    "Manual calendar active": "Aktywny kalendarz ręczny",
+                    "manual calendar active": "Aktywny kalendarz ręczny",
                     "none": "Brak"
                 },
                 "state_attributes": {

--- a/custom_components/boschindego/translations/pl.json
+++ b/custom_components/boschindego/translations/pl.json
@@ -152,7 +152,10 @@
                 "name": "Następne koszenie"
             },
             "mowing_mode": {
-                "name": "Tryb koszenia"
+                "name": "Tryb koszenia",
+                "state": {
+                    "Calendar": "Kalendarz ręczny"
+                }
             },
             "runtime_total": {
                 "name": "Całkowity czas koszenia"
@@ -192,6 +195,332 @@
             },
             "battery_discharge": {
                 "name": "Rozładowanie baterii"
+            },
+            "calendar_slots": {
+                "state": {
+                    "SmartMowing active": "SmartMowing aktywny",
+                    "off": "Wyłączone"
+                },
+                "name": "Zaplanowane czasy koszenia",
+                "state_attributes": {
+                    "today_slot_1": {
+                        "name": "Dzisiejszy przedział 1",
+                        "state": {
+                            "not enabled": "Nieaktywny",
+                            "not configured": "Nie skonfigurowano"
+                        }
+                    },
+                    "today_slot_2": {
+                        "name": "Dzisiejszy przedział 2",
+                        "state": {
+                            "not enabled": "Nieaktywny",
+                            "not configured": "Nie skonfigurowano"
+                        }
+                    },
+                    "monday_slot_1": {
+                        "name": "Poniedziałek Slot 1",
+                        "state": {
+                            "not enabled": "Nieaktywny",
+                            "not configured": "Nie skonfigurowano"
+                        }
+                    },
+                    "monday_slot_2": {
+                        "name": "Poniedziałek Slot 2",
+                        "state": {
+                            "not enabled": "Nieaktywny",
+                            "not configured": "Nie skonfigurowano"
+                        }
+                    },
+                    "tuesday_slot_1": {
+                        "name": "Wtorek Slot 1",
+                        "state": {
+                            "not enabled": "Nieaktywny",
+                            "not configured": "Nie skonfigurowano"
+                        }
+                    },
+                    "tuesday_slot_2": {
+                        "name": "Wtorek Slot 2",
+                        "state": {
+                            "not enabled": "Nieaktywny",
+                            "not configured": "Nie skonfigurowano"
+                        }
+                    },
+                    "wednesday_slot_1": {
+                        "name": "Środa Slot 1",
+                        "state": {
+                            "not enabled": "Nieaktywny",
+                            "not configured": "Nie skonfigurowano"
+                        }
+                    },
+                    "wednesday_slot_2": {
+                        "name": "Środa Slot 2",
+                        "state": {
+                            "not enabled": "Nieaktywny",
+                            "not configured": "Nie skonfigurowano"
+                        }
+                    },
+                    "thursday_slot_1": {
+                        "name": "Czwartek Slot 1",
+                        "state": {
+                            "not enabled": "Nieaktywny",
+                            "not configured": "Nie skonfigurowano"
+                        }
+                    },
+                    "thursday_slot_2": {
+                        "name": "Czwartek Slot 2",
+                        "state": {
+                            "not enabled": "Nieaktywny",
+                            "not configured": "Nie skonfigurowano"
+                        }
+                    },
+                    "friday_slot_1": {
+                        "name": "Piątek Slot 1",
+                        "state": {
+                            "not enabled": "Nieaktywny",
+                            "not configured": "Nie skonfigurowano"
+                        }
+                    },
+                    "friday_slot_2": {
+                        "name": "Piątek Slot 2",
+                        "state": {
+                            "not enabled": "Nieaktywny",
+                            "not configured": "Nie skonfigurowano"
+                        }
+                    },
+                    "saturday_slot_1": {
+                        "name": "Sobota Slot 1",
+                        "state": {
+                            "not enabled": "Nieaktywny",
+                            "not configured": "Nie skonfigurowano"
+                        }
+                    },
+                    "saturday_slot_2": {
+                        "name": "Sobota Slot 2",
+                        "state": {
+                            "not enabled": "Nieaktywny",
+                            "not configured": "Nie skonfigurowano"
+                        }
+                    },
+                    "sunday_slot_1": {
+                        "name": "Niedziela Slot 1",
+                        "state": {
+                            "not enabled": "Nieaktywny",
+                            "not configured": "Nie skonfigurowano"
+                        }
+                    },
+                    "sunday_slot_2": {
+                        "name": "Niedziela Slot 2",
+                        "state": {
+                            "not enabled": "Nieaktywny",
+                            "not configured": "Nie skonfigurowano"
+                        }
+                    }
+                }
+            },
+            "predictive_calendar_slots": {
+                "name": "Okresy blokady SmartMowing",
+                "state": {
+                    "Manual calendar active": "Aktywny kalendarz ręczny",
+                    "off": "Wyłączone"
+                },
+                "state_attributes": {
+                    "last_updated": {
+                        "name": "Ostatnia aktualizacja"
+                    },
+                    "smartmowing_enabled": {
+                        "name": "SmartMowing aktywny"
+                    },
+                    "mowing_mode": {
+                        "name": "Tryb koszenia"
+                    },
+                    "earliest_start": {
+                        "name": "Najwcześniejszy start",
+                        "state": {
+                            "not enabled": "Nieaktywny"
+                        }
+                    },
+                    "latest_end": {
+                        "name": "Najpóźniejsze zakończenie",
+                        "state": {
+                            "not enabled": "Nieaktywny"
+                        }
+                    },
+                    "blocked_before": {
+                        "name": "Zablokowane przed",
+                        "state": {
+                            "not enabled": "Nieaktywny"
+                        }
+                    },
+                    "blocked_after": {
+                        "name": "Zablokowane po",
+                        "state": {
+                            "not enabled": "Nieaktywny"
+                        }
+                    }
+                }
+            },
+            "predictive_schedule": {
+                "name": "Harmonogram SmartMowing",
+                "state": {
+                    "Manual calendar active": "Aktywny kalendarz ręczny",
+                    "none": "Brak"
+                },
+                "state_attributes": {
+                    "last_updated": {
+                        "name": "Ostatnia aktualizacja"
+                    },
+                    "next_mow_slot": {
+                        "name": "Następny zaplanowany przedział koszenia",
+                        "state": {
+                            "none": "Brak"
+                        }
+                    },
+                    "next_mow_day": {
+                        "name": "Następny zaplanowany dzień koszenia",
+                        "state": {
+                            "none": "Brak",
+                            "monday": "Poniedziałek",
+                            "tuesday": "Wtorek",
+                            "wednesday": "Środa",
+                            "thursday": "Czwartek",
+                            "friday": "Piątek",
+                            "saturday": "Sobota",
+                            "sunday": "Niedziela"
+                        }
+                    },
+                    "next_mow_time": {
+                        "name": "Następna zaplanowana godzina koszenia",
+                        "state": {
+                            "none": "Brak"
+                        }
+                    },
+                    "schedule_monday": {
+                        "name": "Harmonogram Poniedziałek",
+                        "state": {
+                            "not scheduled": "Nie zaplanowano"
+                        }
+                    },
+                    "exclusion_monday_user": {
+                        "name": "Czas blokady Poniedziałek użytkownik",
+                        "state": {
+                            "none": "Brak"
+                        }
+                    },
+                    "exclusion_monday_weather": {
+                        "name": "Czas blokady Poniedziałek pogoda",
+                        "state": {
+                            "none": "Brak"
+                        }
+                    },
+                    "schedule_tuesday": {
+                        "name": "Harmonogram Wtorek",
+                        "state": {
+                            "not scheduled": "Nie zaplanowano"
+                        }
+                    },
+                    "exclusion_tuesday_user": {
+                        "name": "Czas blokady Wtorek użytkownik",
+                        "state": {
+                            "none": "Brak"
+                        }
+                    },
+                    "exclusion_tuesday_weather": {
+                        "name": "Czas blokady Wtorek pogoda",
+                        "state": {
+                            "none": "Brak"
+                        }
+                    },
+                    "schedule_wednesday": {
+                        "name": "Harmonogram Środa",
+                        "state": {
+                            "not scheduled": "Nie zaplanowano"
+                        }
+                    },
+                    "exclusion_wednesday_user": {
+                        "name": "Czas blokady Środa użytkownik",
+                        "state": {
+                            "none": "Brak"
+                        }
+                    },
+                    "exclusion_wednesday_weather": {
+                        "name": "Czas blokady Środa pogoda",
+                        "state": {
+                            "none": "Brak"
+                        }
+                    },
+                    "schedule_thursday": {
+                        "name": "Harmonogram Czwartek",
+                        "state": {
+                            "not scheduled": "Nie zaplanowano"
+                        }
+                    },
+                    "exclusion_thursday_user": {
+                        "name": "Czas blokady Czwartek użytkownik",
+                        "state": {
+                            "none": "Brak"
+                        }
+                    },
+                    "exclusion_thursday_weather": {
+                        "name": "Czas blokady Czwartek pogoda",
+                        "state": {
+                            "none": "Brak"
+                        }
+                    },
+                    "schedule_friday": {
+                        "name": "Harmonogram Piątek",
+                        "state": {
+                            "not scheduled": "Nie zaplanowano"
+                        }
+                    },
+                    "exclusion_friday_user": {
+                        "name": "Czas blokady Piątek użytkownik",
+                        "state": {
+                            "none": "Brak"
+                        }
+                    },
+                    "exclusion_friday_weather": {
+                        "name": "Czas blokady Piątek pogoda",
+                        "state": {
+                            "none": "Brak"
+                        }
+                    },
+                    "schedule_saturday": {
+                        "name": "Harmonogram Sobota",
+                        "state": {
+                            "not scheduled": "Nie zaplanowano"
+                        }
+                    },
+                    "exclusion_saturday_user": {
+                        "name": "Czas blokady Sobota użytkownik",
+                        "state": {
+                            "none": "Brak"
+                        }
+                    },
+                    "exclusion_saturday_weather": {
+                        "name": "Czas blokady Sobota pogoda",
+                        "state": {
+                            "none": "Brak"
+                        }
+                    },
+                    "schedule_sunday": {
+                        "name": "Harmonogram Niedziela",
+                        "state": {
+                            "not scheduled": "Nie zaplanowano"
+                        }
+                    },
+                    "exclusion_sunday_user": {
+                        "name": "Czas blokady Niedziela użytkownik",
+                        "state": {
+                            "none": "Brak"
+                        }
+                    },
+                    "exclusion_sunday_weather": {
+                        "name": "Czas blokady Niedziela pogoda",
+                        "state": {
+                            "none": "Brak"
+                        }
+                    }
+                }
             }
         },
         "camera": {

--- a/custom_components/boschindego/translations/sk.json
+++ b/custom_components/boschindego/translations/sk.json
@@ -154,7 +154,7 @@
             "mowing_mode": {
                 "name": "Režim kosenia",
                 "state": {
-                    "Calendar": "Manuálny kalendár"
+                    "calendar": "Manuálny kalendár"
                 }
             },
             "runtime_total": {
@@ -198,7 +198,7 @@
             },
             "calendar_slots": {
                 "state": {
-                    "smartmowing active": "SmartMowing aktívny",
+                    "smartmowing_active": "SmartMowing aktívny",
                     "off": "Vypnuté"
                 },
                 "name": "Naplánované časy kosenia",
@@ -206,113 +206,113 @@
                     "today_slot_1": {
                         "name": "Dnešný slot 1",
                         "state": {
-                            "not enabled": "Neaktivované",
-                            "not configured": "Nenakonfigurované"
+                            "not_enabled": "Neaktivované",
+                            "not_configured": "Nenakonfigurované"
                         }
                     },
                     "today_slot_2": {
                         "name": "Dnešný slot 2",
                         "state": {
-                            "not enabled": "Neaktivované",
-                            "not configured": "Nenakonfigurované"
+                            "not_enabled": "Neaktivované",
+                            "not_configured": "Nenakonfigurované"
                         }
                     },
                     "monday_slot_1": {
                         "name": "Pondelok Slot 1",
                         "state": {
-                            "not enabled": "Neaktivované",
-                            "not configured": "Nenakonfigurované"
+                            "not_enabled": "Neaktivované",
+                            "not_configured": "Nenakonfigurované"
                         }
                     },
                     "monday_slot_2": {
                         "name": "Pondelok Slot 2",
                         "state": {
-                            "not enabled": "Neaktivované",
-                            "not configured": "Nenakonfigurované"
+                            "not_enabled": "Neaktivované",
+                            "not_configured": "Nenakonfigurované"
                         }
                     },
                     "tuesday_slot_1": {
                         "name": "Utorok Slot 1",
                         "state": {
-                            "not enabled": "Neaktivované",
-                            "not configured": "Nenakonfigurované"
+                            "not_enabled": "Neaktivované",
+                            "not_configured": "Nenakonfigurované"
                         }
                     },
                     "tuesday_slot_2": {
                         "name": "Utorok Slot 2",
                         "state": {
-                            "not enabled": "Neaktivované",
-                            "not configured": "Nenakonfigurované"
+                            "not_enabled": "Neaktivované",
+                            "not_configured": "Nenakonfigurované"
                         }
                     },
                     "wednesday_slot_1": {
                         "name": "Streda Slot 1",
                         "state": {
-                            "not enabled": "Neaktivované",
-                            "not configured": "Nenakonfigurované"
+                            "not_enabled": "Neaktivované",
+                            "not_configured": "Nenakonfigurované"
                         }
                     },
                     "wednesday_slot_2": {
                         "name": "Streda Slot 2",
                         "state": {
-                            "not enabled": "Neaktivované",
-                            "not configured": "Nenakonfigurované"
+                            "not_enabled": "Neaktivované",
+                            "not_configured": "Nenakonfigurované"
                         }
                     },
                     "thursday_slot_1": {
                         "name": "Štvrtok Slot 1",
                         "state": {
-                            "not enabled": "Neaktivované",
-                            "not configured": "Nenakonfigurované"
+                            "not_enabled": "Neaktivované",
+                            "not_configured": "Nenakonfigurované"
                         }
                     },
                     "thursday_slot_2": {
                         "name": "Štvrtok Slot 2",
                         "state": {
-                            "not enabled": "Neaktivované",
-                            "not configured": "Nenakonfigurované"
+                            "not_enabled": "Neaktivované",
+                            "not_configured": "Nenakonfigurované"
                         }
                     },
                     "friday_slot_1": {
                         "name": "Piatok Slot 1",
                         "state": {
-                            "not enabled": "Neaktivované",
-                            "not configured": "Nenakonfigurované"
+                            "not_enabled": "Neaktivované",
+                            "not_configured": "Nenakonfigurované"
                         }
                     },
                     "friday_slot_2": {
                         "name": "Piatok Slot 2",
                         "state": {
-                            "not enabled": "Neaktivované",
-                            "not configured": "Nenakonfigurované"
+                            "not_enabled": "Neaktivované",
+                            "not_configured": "Nenakonfigurované"
                         }
                     },
                     "saturday_slot_1": {
                         "name": "Sobota Slot 1",
                         "state": {
-                            "not enabled": "Neaktivované",
-                            "not configured": "Nenakonfigurované"
+                            "not_enabled": "Neaktivované",
+                            "not_configured": "Nenakonfigurované"
                         }
                     },
                     "saturday_slot_2": {
                         "name": "Sobota Slot 2",
                         "state": {
-                            "not enabled": "Neaktivované",
-                            "not configured": "Nenakonfigurované"
+                            "not_enabled": "Neaktivované",
+                            "not_configured": "Nenakonfigurované"
                         }
                     },
                     "sunday_slot_1": {
                         "name": "Nedeľa Slot 1",
                         "state": {
-                            "not enabled": "Neaktivované",
-                            "not configured": "Nenakonfigurované"
+                            "not_enabled": "Neaktivované",
+                            "not_configured": "Nenakonfigurované"
                         }
                     },
                     "sunday_slot_2": {
                         "name": "Nedeľa Slot 2",
                         "state": {
-                            "not enabled": "Neaktivované",
-                            "not configured": "Nenakonfigurované"
+                            "not_enabled": "Neaktivované",
+                            "not_configured": "Nenakonfigurované"
                         }
                     }
                 }
@@ -320,7 +320,7 @@
             "predictive_calendar_slots": {
                 "name": "Blokované časy SmartMowing",
                 "state": {
-                    "manual calendar active": "Manuálny kalendár aktívny",
+                    "manual_calendar_active": "Manuálny kalendár aktívny",
                     "off": "Vypnuté"
                 },
                 "state_attributes": {
@@ -336,25 +336,25 @@
                     "earliest_start": {
                         "name": "Najskorší začiatok",
                         "state": {
-                            "not enabled": "Neaktivované"
+                            "not_enabled": "Neaktivované"
                         }
                     },
                     "latest_end": {
                         "name": "Najneskorší koniec",
                         "state": {
-                            "not enabled": "Neaktivované"
+                            "not_enabled": "Neaktivované"
                         }
                     },
                     "blocked_before": {
                         "name": "Blokované pred",
                         "state": {
-                            "not enabled": "Neaktivované"
+                            "not_enabled": "Neaktivované"
                         }
                     },
                     "blocked_after": {
                         "name": "Blokované po",
                         "state": {
-                            "not enabled": "Neaktivované"
+                            "not_enabled": "Neaktivované"
                         }
                     }
                 }
@@ -362,7 +362,7 @@
             "predictive_schedule": {
                 "name": "Plán SmartMowing",
                 "state": {
-                    "manual calendar active": "Manuálny kalendár aktívny",
+                    "manual_calendar_active": "Manuálny kalendár aktívny",
                     "none": "Žiadne"
                 },
                 "state_attributes": {
@@ -397,7 +397,7 @@
                     "schedule_monday": {
                         "name": "Plán Pondelok",
                         "state": {
-                            "not scheduled": "Nenaplánované"
+                            "not_scheduled": "Nenaplánované"
                         }
                     },
                     "exclusion_monday_user": {
@@ -415,7 +415,7 @@
                     "schedule_tuesday": {
                         "name": "Plán Utorok",
                         "state": {
-                            "not scheduled": "Nenaplánované"
+                            "not_scheduled": "Nenaplánované"
                         }
                     },
                     "exclusion_tuesday_user": {
@@ -433,7 +433,7 @@
                     "schedule_wednesday": {
                         "name": "Plán Streda",
                         "state": {
-                            "not scheduled": "Nenaplánované"
+                            "not_scheduled": "Nenaplánované"
                         }
                     },
                     "exclusion_wednesday_user": {
@@ -451,7 +451,7 @@
                     "schedule_thursday": {
                         "name": "Plán Štvrtok",
                         "state": {
-                            "not scheduled": "Nenaplánované"
+                            "not_scheduled": "Nenaplánované"
                         }
                     },
                     "exclusion_thursday_user": {
@@ -469,7 +469,7 @@
                     "schedule_friday": {
                         "name": "Plán Piatok",
                         "state": {
-                            "not scheduled": "Nenaplánované"
+                            "not_scheduled": "Nenaplánované"
                         }
                     },
                     "exclusion_friday_user": {
@@ -487,7 +487,7 @@
                     "schedule_saturday": {
                         "name": "Plán Sobota",
                         "state": {
-                            "not scheduled": "Nenaplánované"
+                            "not_scheduled": "Nenaplánované"
                         }
                     },
                     "exclusion_saturday_user": {
@@ -505,7 +505,7 @@
                     "schedule_sunday": {
                         "name": "Plán Nedeľa",
                         "state": {
-                            "not scheduled": "Nenaplánované"
+                            "not_scheduled": "Nenaplánované"
                         }
                     },
                     "exclusion_sunday_user": {

--- a/custom_components/boschindego/translations/sk.json
+++ b/custom_components/boschindego/translations/sk.json
@@ -198,7 +198,7 @@
             },
             "calendar_slots": {
                 "state": {
-                    "SmartMowing active": "SmartMowing aktívny",
+                    "smartmowing active": "SmartMowing aktívny",
                     "off": "Vypnuté"
                 },
                 "name": "Naplánované časy kosenia",
@@ -320,7 +320,7 @@
             "predictive_calendar_slots": {
                 "name": "Blokované časy SmartMowing",
                 "state": {
-                    "Manual calendar active": "Manuálny kalendár aktívny",
+                    "manual calendar active": "Manuálny kalendár aktívny",
                     "off": "Vypnuté"
                 },
                 "state_attributes": {
@@ -362,7 +362,7 @@
             "predictive_schedule": {
                 "name": "Plán SmartMowing",
                 "state": {
-                    "Manual calendar active": "Manuálny kalendár aktívny",
+                    "manual calendar active": "Manuálny kalendár aktívny",
                     "none": "Žiadne"
                 },
                 "state_attributes": {

--- a/custom_components/boschindego/translations/sk.json
+++ b/custom_components/boschindego/translations/sk.json
@@ -152,7 +152,10 @@
                 "name": "Budúce kosenie"
             },
             "mowing_mode": {
-                "name": "Režim kosenia"
+                "name": "Režim kosenia",
+                "state": {
+                    "Calendar": "Manuálny kalendár"
+                }
             },
             "runtime_total": {
                 "name": "Celkový čas kosenia"
@@ -192,6 +195,332 @@
             },
             "battery_discharge": {
                 "name": "Vybíjanie batérie"
+            },
+            "calendar_slots": {
+                "state": {
+                    "SmartMowing active": "SmartMowing aktívny",
+                    "off": "Vypnuté"
+                },
+                "name": "Naplánované časy kosenia",
+                "state_attributes": {
+                    "today_slot_1": {
+                        "name": "Dnešný slot 1",
+                        "state": {
+                            "not enabled": "Neaktivované",
+                            "not configured": "Nenakonfigurované"
+                        }
+                    },
+                    "today_slot_2": {
+                        "name": "Dnešný slot 2",
+                        "state": {
+                            "not enabled": "Neaktivované",
+                            "not configured": "Nenakonfigurované"
+                        }
+                    },
+                    "monday_slot_1": {
+                        "name": "Pondelok Slot 1",
+                        "state": {
+                            "not enabled": "Neaktivované",
+                            "not configured": "Nenakonfigurované"
+                        }
+                    },
+                    "monday_slot_2": {
+                        "name": "Pondelok Slot 2",
+                        "state": {
+                            "not enabled": "Neaktivované",
+                            "not configured": "Nenakonfigurované"
+                        }
+                    },
+                    "tuesday_slot_1": {
+                        "name": "Utorok Slot 1",
+                        "state": {
+                            "not enabled": "Neaktivované",
+                            "not configured": "Nenakonfigurované"
+                        }
+                    },
+                    "tuesday_slot_2": {
+                        "name": "Utorok Slot 2",
+                        "state": {
+                            "not enabled": "Neaktivované",
+                            "not configured": "Nenakonfigurované"
+                        }
+                    },
+                    "wednesday_slot_1": {
+                        "name": "Streda Slot 1",
+                        "state": {
+                            "not enabled": "Neaktivované",
+                            "not configured": "Nenakonfigurované"
+                        }
+                    },
+                    "wednesday_slot_2": {
+                        "name": "Streda Slot 2",
+                        "state": {
+                            "not enabled": "Neaktivované",
+                            "not configured": "Nenakonfigurované"
+                        }
+                    },
+                    "thursday_slot_1": {
+                        "name": "Štvrtok Slot 1",
+                        "state": {
+                            "not enabled": "Neaktivované",
+                            "not configured": "Nenakonfigurované"
+                        }
+                    },
+                    "thursday_slot_2": {
+                        "name": "Štvrtok Slot 2",
+                        "state": {
+                            "not enabled": "Neaktivované",
+                            "not configured": "Nenakonfigurované"
+                        }
+                    },
+                    "friday_slot_1": {
+                        "name": "Piatok Slot 1",
+                        "state": {
+                            "not enabled": "Neaktivované",
+                            "not configured": "Nenakonfigurované"
+                        }
+                    },
+                    "friday_slot_2": {
+                        "name": "Piatok Slot 2",
+                        "state": {
+                            "not enabled": "Neaktivované",
+                            "not configured": "Nenakonfigurované"
+                        }
+                    },
+                    "saturday_slot_1": {
+                        "name": "Sobota Slot 1",
+                        "state": {
+                            "not enabled": "Neaktivované",
+                            "not configured": "Nenakonfigurované"
+                        }
+                    },
+                    "saturday_slot_2": {
+                        "name": "Sobota Slot 2",
+                        "state": {
+                            "not enabled": "Neaktivované",
+                            "not configured": "Nenakonfigurované"
+                        }
+                    },
+                    "sunday_slot_1": {
+                        "name": "Nedeľa Slot 1",
+                        "state": {
+                            "not enabled": "Neaktivované",
+                            "not configured": "Nenakonfigurované"
+                        }
+                    },
+                    "sunday_slot_2": {
+                        "name": "Nedeľa Slot 2",
+                        "state": {
+                            "not enabled": "Neaktivované",
+                            "not configured": "Nenakonfigurované"
+                        }
+                    }
+                }
+            },
+            "predictive_calendar_slots": {
+                "name": "Blokované časy SmartMowing",
+                "state": {
+                    "Manual calendar active": "Manuálny kalendár aktívny",
+                    "off": "Vypnuté"
+                },
+                "state_attributes": {
+                    "last_updated": {
+                        "name": "Naposledy aktualizované"
+                    },
+                    "smartmowing_enabled": {
+                        "name": "SmartMowing aktívny"
+                    },
+                    "mowing_mode": {
+                        "name": "Režim kosenia"
+                    },
+                    "earliest_start": {
+                        "name": "Najskorší začiatok",
+                        "state": {
+                            "not enabled": "Neaktivované"
+                        }
+                    },
+                    "latest_end": {
+                        "name": "Najneskorší koniec",
+                        "state": {
+                            "not enabled": "Neaktivované"
+                        }
+                    },
+                    "blocked_before": {
+                        "name": "Blokované pred",
+                        "state": {
+                            "not enabled": "Neaktivované"
+                        }
+                    },
+                    "blocked_after": {
+                        "name": "Blokované po",
+                        "state": {
+                            "not enabled": "Neaktivované"
+                        }
+                    }
+                }
+            },
+            "predictive_schedule": {
+                "name": "Plán SmartMowing",
+                "state": {
+                    "Manual calendar active": "Manuálny kalendár aktívny",
+                    "none": "Žiadne"
+                },
+                "state_attributes": {
+                    "last_updated": {
+                        "name": "Naposledy aktualizované"
+                    },
+                    "next_mow_slot": {
+                        "name": "Ďalší naplánovaný časový slot kosenia",
+                        "state": {
+                            "none": "Žiadne"
+                        }
+                    },
+                    "next_mow_day": {
+                        "name": "Ďalší naplánovaný deň kosenia",
+                        "state": {
+                            "none": "Žiadne",
+                            "monday": "Pondelok",
+                            "tuesday": "Utorok",
+                            "wednesday": "Streda",
+                            "thursday": "Štvrtok",
+                            "friday": "Piatok",
+                            "saturday": "Sobota",
+                            "sunday": "Nedeľa"
+                        }
+                    },
+                    "next_mow_time": {
+                        "name": "Ďalší naplánovaný čas kosenia",
+                        "state": {
+                            "none": "Žiadne"
+                        }
+                    },
+                    "schedule_monday": {
+                        "name": "Plán Pondelok",
+                        "state": {
+                            "not scheduled": "Nenaplánované"
+                        }
+                    },
+                    "exclusion_monday_user": {
+                        "name": "Blokovaný čas Pondelok používateľ",
+                        "state": {
+                            "none": "Žiadne"
+                        }
+                    },
+                    "exclusion_monday_weather": {
+                        "name": "Blokovaný čas Pondelok počasie",
+                        "state": {
+                            "none": "Žiadne"
+                        }
+                    },
+                    "schedule_tuesday": {
+                        "name": "Plán Utorok",
+                        "state": {
+                            "not scheduled": "Nenaplánované"
+                        }
+                    },
+                    "exclusion_tuesday_user": {
+                        "name": "Blokovaný čas Utorok používateľ",
+                        "state": {
+                            "none": "Žiadne"
+                        }
+                    },
+                    "exclusion_tuesday_weather": {
+                        "name": "Blokovaný čas Utorok počasie",
+                        "state": {
+                            "none": "Žiadne"
+                        }
+                    },
+                    "schedule_wednesday": {
+                        "name": "Plán Streda",
+                        "state": {
+                            "not scheduled": "Nenaplánované"
+                        }
+                    },
+                    "exclusion_wednesday_user": {
+                        "name": "Blokovaný čas Streda používateľ",
+                        "state": {
+                            "none": "Žiadne"
+                        }
+                    },
+                    "exclusion_wednesday_weather": {
+                        "name": "Blokovaný čas Streda počasie",
+                        "state": {
+                            "none": "Žiadne"
+                        }
+                    },
+                    "schedule_thursday": {
+                        "name": "Plán Štvrtok",
+                        "state": {
+                            "not scheduled": "Nenaplánované"
+                        }
+                    },
+                    "exclusion_thursday_user": {
+                        "name": "Blokovaný čas Štvrtok používateľ",
+                        "state": {
+                            "none": "Žiadne"
+                        }
+                    },
+                    "exclusion_thursday_weather": {
+                        "name": "Blokovaný čas Štvrtok počasie",
+                        "state": {
+                            "none": "Žiadne"
+                        }
+                    },
+                    "schedule_friday": {
+                        "name": "Plán Piatok",
+                        "state": {
+                            "not scheduled": "Nenaplánované"
+                        }
+                    },
+                    "exclusion_friday_user": {
+                        "name": "Blokovaný čas Piatok používateľ",
+                        "state": {
+                            "none": "Žiadne"
+                        }
+                    },
+                    "exclusion_friday_weather": {
+                        "name": "Blokovaný čas Piatok počasie",
+                        "state": {
+                            "none": "Žiadne"
+                        }
+                    },
+                    "schedule_saturday": {
+                        "name": "Plán Sobota",
+                        "state": {
+                            "not scheduled": "Nenaplánované"
+                        }
+                    },
+                    "exclusion_saturday_user": {
+                        "name": "Blokovaný čas Sobota používateľ",
+                        "state": {
+                            "none": "Žiadne"
+                        }
+                    },
+                    "exclusion_saturday_weather": {
+                        "name": "Blokovaný čas Sobota počasie",
+                        "state": {
+                            "none": "Žiadne"
+                        }
+                    },
+                    "schedule_sunday": {
+                        "name": "Plán Nedeľa",
+                        "state": {
+                            "not scheduled": "Nenaplánované"
+                        }
+                    },
+                    "exclusion_sunday_user": {
+                        "name": "Blokovaný čas Nedeľa používateľ",
+                        "state": {
+                            "none": "Žiadne"
+                        }
+                    },
+                    "exclusion_sunday_weather": {
+                        "name": "Blokovaný čas Nedeľa počasie",
+                        "state": {
+                            "none": "Žiadne"
+                        }
+                    }
+                }
             }
         },
         "camera": {

--- a/custom_components/boschindego/translations/sv.json
+++ b/custom_components/boschindego/translations/sv.json
@@ -154,7 +154,7 @@
             "mowing_mode": {
                 "name": "Klippläge",
                 "state": {
-                    "Calendar": "Manuell kalender"
+                    "calendar": "Manuell kalender"
                 }
             },
             "runtime_total": {
@@ -198,7 +198,7 @@
             },
             "calendar_slots": {
                 "state": {
-                    "smartmowing active": "SmartMowing aktiv",
+                    "smartmowing_active": "SmartMowing aktiv",
                     "off": "Av"
                 },
                 "name": "Planerade klipptider",
@@ -206,113 +206,113 @@
                     "today_slot_1": {
                         "name": "Dagens intervall 1",
                         "state": {
-                            "not enabled": "Inte aktiverad",
-                            "not configured": "Inte konfigurerad"
+                            "not_enabled": "Inte aktiverad",
+                            "not_configured": "Inte konfigurerad"
                         }
                     },
                     "today_slot_2": {
                         "name": "Dagens intervall 2",
                         "state": {
-                            "not enabled": "Inte aktiverad",
-                            "not configured": "Inte konfigurerad"
+                            "not_enabled": "Inte aktiverad",
+                            "not_configured": "Inte konfigurerad"
                         }
                     },
                     "monday_slot_1": {
                         "name": "Måndag Slot 1",
                         "state": {
-                            "not enabled": "Inte aktiverad",
-                            "not configured": "Inte konfigurerad"
+                            "not_enabled": "Inte aktiverad",
+                            "not_configured": "Inte konfigurerad"
                         }
                     },
                     "monday_slot_2": {
                         "name": "Måndag Slot 2",
                         "state": {
-                            "not enabled": "Inte aktiverad",
-                            "not configured": "Inte konfigurerad"
+                            "not_enabled": "Inte aktiverad",
+                            "not_configured": "Inte konfigurerad"
                         }
                     },
                     "tuesday_slot_1": {
                         "name": "Tisdag Slot 1",
                         "state": {
-                            "not enabled": "Inte aktiverad",
-                            "not configured": "Inte konfigurerad"
+                            "not_enabled": "Inte aktiverad",
+                            "not_configured": "Inte konfigurerad"
                         }
                     },
                     "tuesday_slot_2": {
                         "name": "Tisdag Slot 2",
                         "state": {
-                            "not enabled": "Inte aktiverad",
-                            "not configured": "Inte konfigurerad"
+                            "not_enabled": "Inte aktiverad",
+                            "not_configured": "Inte konfigurerad"
                         }
                     },
                     "wednesday_slot_1": {
                         "name": "Onsdag Slot 1",
                         "state": {
-                            "not enabled": "Inte aktiverad",
-                            "not configured": "Inte konfigurerad"
+                            "not_enabled": "Inte aktiverad",
+                            "not_configured": "Inte konfigurerad"
                         }
                     },
                     "wednesday_slot_2": {
                         "name": "Onsdag Slot 2",
                         "state": {
-                            "not enabled": "Inte aktiverad",
-                            "not configured": "Inte konfigurerad"
+                            "not_enabled": "Inte aktiverad",
+                            "not_configured": "Inte konfigurerad"
                         }
                     },
                     "thursday_slot_1": {
                         "name": "Torsdag Slot 1",
                         "state": {
-                            "not enabled": "Inte aktiverad",
-                            "not configured": "Inte konfigurerad"
+                            "not_enabled": "Inte aktiverad",
+                            "not_configured": "Inte konfigurerad"
                         }
                     },
                     "thursday_slot_2": {
                         "name": "Torsdag Slot 2",
                         "state": {
-                            "not enabled": "Inte aktiverad",
-                            "not configured": "Inte konfigurerad"
+                            "not_enabled": "Inte aktiverad",
+                            "not_configured": "Inte konfigurerad"
                         }
                     },
                     "friday_slot_1": {
                         "name": "Fredag Slot 1",
                         "state": {
-                            "not enabled": "Inte aktiverad",
-                            "not configured": "Inte konfigurerad"
+                            "not_enabled": "Inte aktiverad",
+                            "not_configured": "Inte konfigurerad"
                         }
                     },
                     "friday_slot_2": {
                         "name": "Fredag Slot 2",
                         "state": {
-                            "not enabled": "Inte aktiverad",
-                            "not configured": "Inte konfigurerad"
+                            "not_enabled": "Inte aktiverad",
+                            "not_configured": "Inte konfigurerad"
                         }
                     },
                     "saturday_slot_1": {
                         "name": "Lördag Slot 1",
                         "state": {
-                            "not enabled": "Inte aktiverad",
-                            "not configured": "Inte konfigurerad"
+                            "not_enabled": "Inte aktiverad",
+                            "not_configured": "Inte konfigurerad"
                         }
                     },
                     "saturday_slot_2": {
                         "name": "Lördag Slot 2",
                         "state": {
-                            "not enabled": "Inte aktiverad",
-                            "not configured": "Inte konfigurerad"
+                            "not_enabled": "Inte aktiverad",
+                            "not_configured": "Inte konfigurerad"
                         }
                     },
                     "sunday_slot_1": {
                         "name": "Söndag Slot 1",
                         "state": {
-                            "not enabled": "Inte aktiverad",
-                            "not configured": "Inte konfigurerad"
+                            "not_enabled": "Inte aktiverad",
+                            "not_configured": "Inte konfigurerad"
                         }
                     },
                     "sunday_slot_2": {
                         "name": "Söndag Slot 2",
                         "state": {
-                            "not enabled": "Inte aktiverad",
-                            "not configured": "Inte konfigurerad"
+                            "not_enabled": "Inte aktiverad",
+                            "not_configured": "Inte konfigurerad"
                         }
                     }
                 }
@@ -320,7 +320,7 @@
             "predictive_calendar_slots": {
                 "name": "SmartMowing-blockerade tider",
                 "state": {
-                    "manual calendar active": "Manuell kalender aktiv",
+                    "manual_calendar_active": "Manuell kalender aktiv",
                     "off": "Av"
                 },
                 "state_attributes": {
@@ -336,25 +336,25 @@
                     "earliest_start": {
                         "name": "Tidigaste start",
                         "state": {
-                            "not enabled": "Inte aktiverad"
+                            "not_enabled": "Inte aktiverad"
                         }
                     },
                     "latest_end": {
                         "name": "Senaste slut",
                         "state": {
-                            "not enabled": "Inte aktiverad"
+                            "not_enabled": "Inte aktiverad"
                         }
                     },
                     "blocked_before": {
                         "name": "Blockerat före",
                         "state": {
-                            "not enabled": "Inte aktiverad"
+                            "not_enabled": "Inte aktiverad"
                         }
                     },
                     "blocked_after": {
                         "name": "Blockerat efter",
                         "state": {
-                            "not enabled": "Inte aktiverad"
+                            "not_enabled": "Inte aktiverad"
                         }
                     }
                 }
@@ -362,7 +362,7 @@
             "predictive_schedule": {
                 "name": "SmartMowing-schema",
                 "state": {
-                    "manual calendar active": "Manuell kalender aktiv",
+                    "manual_calendar_active": "Manuell kalender aktiv",
                     "none": "Ingen"
                 },
                 "state_attributes": {
@@ -397,7 +397,7 @@
                     "schedule_monday": {
                         "name": "Schema Måndag",
                         "state": {
-                            "not scheduled": "Inte planerad"
+                            "not_scheduled": "Inte planerad"
                         }
                     },
                     "exclusion_monday_user": {
@@ -415,7 +415,7 @@
                     "schedule_tuesday": {
                         "name": "Schema Tisdag",
                         "state": {
-                            "not scheduled": "Inte planerad"
+                            "not_scheduled": "Inte planerad"
                         }
                     },
                     "exclusion_tuesday_user": {
@@ -433,7 +433,7 @@
                     "schedule_wednesday": {
                         "name": "Schema Onsdag",
                         "state": {
-                            "not scheduled": "Inte planerad"
+                            "not_scheduled": "Inte planerad"
                         }
                     },
                     "exclusion_wednesday_user": {
@@ -451,7 +451,7 @@
                     "schedule_thursday": {
                         "name": "Schema Torsdag",
                         "state": {
-                            "not scheduled": "Inte planerad"
+                            "not_scheduled": "Inte planerad"
                         }
                     },
                     "exclusion_thursday_user": {
@@ -469,7 +469,7 @@
                     "schedule_friday": {
                         "name": "Schema Fredag",
                         "state": {
-                            "not scheduled": "Inte planerad"
+                            "not_scheduled": "Inte planerad"
                         }
                     },
                     "exclusion_friday_user": {
@@ -487,7 +487,7 @@
                     "schedule_saturday": {
                         "name": "Schema Lördag",
                         "state": {
-                            "not scheduled": "Inte planerad"
+                            "not_scheduled": "Inte planerad"
                         }
                     },
                     "exclusion_saturday_user": {
@@ -505,7 +505,7 @@
                     "schedule_sunday": {
                         "name": "Schema Söndag",
                         "state": {
-                            "not scheduled": "Inte planerad"
+                            "not_scheduled": "Inte planerad"
                         }
                     },
                     "exclusion_sunday_user": {

--- a/custom_components/boschindego/translations/sv.json
+++ b/custom_components/boschindego/translations/sv.json
@@ -152,7 +152,10 @@
                 "name": "Nästa klippning"
             },
             "mowing_mode": {
-                "name": "Klippläge"
+                "name": "Klippläge",
+                "state": {
+                    "Calendar": "Manuell kalender"
+                }
             },
             "runtime_total": {
                 "name": "Total klippetid"
@@ -192,6 +195,332 @@
             },
             "battery_discharge": {
                 "name": "Batteriavlastning"
+            },
+            "calendar_slots": {
+                "state": {
+                    "SmartMowing active": "SmartMowing aktiv",
+                    "off": "Av"
+                },
+                "name": "Planerade klipptider",
+                "state_attributes": {
+                    "today_slot_1": {
+                        "name": "Dagens intervall 1",
+                        "state": {
+                            "not enabled": "Inte aktiverad",
+                            "not configured": "Inte konfigurerad"
+                        }
+                    },
+                    "today_slot_2": {
+                        "name": "Dagens intervall 2",
+                        "state": {
+                            "not enabled": "Inte aktiverad",
+                            "not configured": "Inte konfigurerad"
+                        }
+                    },
+                    "monday_slot_1": {
+                        "name": "Måndag Slot 1",
+                        "state": {
+                            "not enabled": "Inte aktiverad",
+                            "not configured": "Inte konfigurerad"
+                        }
+                    },
+                    "monday_slot_2": {
+                        "name": "Måndag Slot 2",
+                        "state": {
+                            "not enabled": "Inte aktiverad",
+                            "not configured": "Inte konfigurerad"
+                        }
+                    },
+                    "tuesday_slot_1": {
+                        "name": "Tisdag Slot 1",
+                        "state": {
+                            "not enabled": "Inte aktiverad",
+                            "not configured": "Inte konfigurerad"
+                        }
+                    },
+                    "tuesday_slot_2": {
+                        "name": "Tisdag Slot 2",
+                        "state": {
+                            "not enabled": "Inte aktiverad",
+                            "not configured": "Inte konfigurerad"
+                        }
+                    },
+                    "wednesday_slot_1": {
+                        "name": "Onsdag Slot 1",
+                        "state": {
+                            "not enabled": "Inte aktiverad",
+                            "not configured": "Inte konfigurerad"
+                        }
+                    },
+                    "wednesday_slot_2": {
+                        "name": "Onsdag Slot 2",
+                        "state": {
+                            "not enabled": "Inte aktiverad",
+                            "not configured": "Inte konfigurerad"
+                        }
+                    },
+                    "thursday_slot_1": {
+                        "name": "Torsdag Slot 1",
+                        "state": {
+                            "not enabled": "Inte aktiverad",
+                            "not configured": "Inte konfigurerad"
+                        }
+                    },
+                    "thursday_slot_2": {
+                        "name": "Torsdag Slot 2",
+                        "state": {
+                            "not enabled": "Inte aktiverad",
+                            "not configured": "Inte konfigurerad"
+                        }
+                    },
+                    "friday_slot_1": {
+                        "name": "Fredag Slot 1",
+                        "state": {
+                            "not enabled": "Inte aktiverad",
+                            "not configured": "Inte konfigurerad"
+                        }
+                    },
+                    "friday_slot_2": {
+                        "name": "Fredag Slot 2",
+                        "state": {
+                            "not enabled": "Inte aktiverad",
+                            "not configured": "Inte konfigurerad"
+                        }
+                    },
+                    "saturday_slot_1": {
+                        "name": "Lördag Slot 1",
+                        "state": {
+                            "not enabled": "Inte aktiverad",
+                            "not configured": "Inte konfigurerad"
+                        }
+                    },
+                    "saturday_slot_2": {
+                        "name": "Lördag Slot 2",
+                        "state": {
+                            "not enabled": "Inte aktiverad",
+                            "not configured": "Inte konfigurerad"
+                        }
+                    },
+                    "sunday_slot_1": {
+                        "name": "Söndag Slot 1",
+                        "state": {
+                            "not enabled": "Inte aktiverad",
+                            "not configured": "Inte konfigurerad"
+                        }
+                    },
+                    "sunday_slot_2": {
+                        "name": "Söndag Slot 2",
+                        "state": {
+                            "not enabled": "Inte aktiverad",
+                            "not configured": "Inte konfigurerad"
+                        }
+                    }
+                }
+            },
+            "predictive_calendar_slots": {
+                "name": "SmartMowing-blockerade tider",
+                "state": {
+                    "Manual calendar active": "Manuell kalender aktiv",
+                    "off": "Av"
+                },
+                "state_attributes": {
+                    "last_updated": {
+                        "name": "Senast uppdaterad"
+                    },
+                    "smartmowing_enabled": {
+                        "name": "SmartMowing aktiv"
+                    },
+                    "mowing_mode": {
+                        "name": "Klippläge"
+                    },
+                    "earliest_start": {
+                        "name": "Tidigaste start",
+                        "state": {
+                            "not enabled": "Inte aktiverad"
+                        }
+                    },
+                    "latest_end": {
+                        "name": "Senaste slut",
+                        "state": {
+                            "not enabled": "Inte aktiverad"
+                        }
+                    },
+                    "blocked_before": {
+                        "name": "Blockerat före",
+                        "state": {
+                            "not enabled": "Inte aktiverad"
+                        }
+                    },
+                    "blocked_after": {
+                        "name": "Blockerat efter",
+                        "state": {
+                            "not enabled": "Inte aktiverad"
+                        }
+                    }
+                }
+            },
+            "predictive_schedule": {
+                "name": "SmartMowing-schema",
+                "state": {
+                    "Manual calendar active": "Manuell kalender aktiv",
+                    "none": "Ingen"
+                },
+                "state_attributes": {
+                    "last_updated": {
+                        "name": "Senast uppdaterad"
+                    },
+                    "next_mow_slot": {
+                        "name": "Nästa planerade klippintervall",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "next_mow_day": {
+                        "name": "Nästa planerade klippdag",
+                        "state": {
+                            "none": "Ingen",
+                            "monday": "Måndag",
+                            "tuesday": "Tisdag",
+                            "wednesday": "Onsdag",
+                            "thursday": "Torsdag",
+                            "friday": "Fredag",
+                            "saturday": "Lördag",
+                            "sunday": "Söndag"
+                        }
+                    },
+                    "next_mow_time": {
+                        "name": "Nästa planerade klipptid",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "schedule_monday": {
+                        "name": "Schema Måndag",
+                        "state": {
+                            "not scheduled": "Inte planerad"
+                        }
+                    },
+                    "exclusion_monday_user": {
+                        "name": "Blockerad tid Måndag användare",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "exclusion_monday_weather": {
+                        "name": "Blockerad tid Måndag väder",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "schedule_tuesday": {
+                        "name": "Schema Tisdag",
+                        "state": {
+                            "not scheduled": "Inte planerad"
+                        }
+                    },
+                    "exclusion_tuesday_user": {
+                        "name": "Blockerad tid Tisdag användare",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "exclusion_tuesday_weather": {
+                        "name": "Blockerad tid Tisdag väder",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "schedule_wednesday": {
+                        "name": "Schema Onsdag",
+                        "state": {
+                            "not scheduled": "Inte planerad"
+                        }
+                    },
+                    "exclusion_wednesday_user": {
+                        "name": "Blockerad tid Onsdag användare",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "exclusion_wednesday_weather": {
+                        "name": "Blockerad tid Onsdag väder",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "schedule_thursday": {
+                        "name": "Schema Torsdag",
+                        "state": {
+                            "not scheduled": "Inte planerad"
+                        }
+                    },
+                    "exclusion_thursday_user": {
+                        "name": "Blockerad tid Torsdag användare",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "exclusion_thursday_weather": {
+                        "name": "Blockerad tid Torsdag väder",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "schedule_friday": {
+                        "name": "Schema Fredag",
+                        "state": {
+                            "not scheduled": "Inte planerad"
+                        }
+                    },
+                    "exclusion_friday_user": {
+                        "name": "Blockerad tid Fredag användare",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "exclusion_friday_weather": {
+                        "name": "Blockerad tid Fredag väder",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "schedule_saturday": {
+                        "name": "Schema Lördag",
+                        "state": {
+                            "not scheduled": "Inte planerad"
+                        }
+                    },
+                    "exclusion_saturday_user": {
+                        "name": "Blockerad tid Lördag användare",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "exclusion_saturday_weather": {
+                        "name": "Blockerad tid Lördag väder",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "schedule_sunday": {
+                        "name": "Schema Söndag",
+                        "state": {
+                            "not scheduled": "Inte planerad"
+                        }
+                    },
+                    "exclusion_sunday_user": {
+                        "name": "Blockerad tid Söndag användare",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    },
+                    "exclusion_sunday_weather": {
+                        "name": "Blockerad tid Söndag väder",
+                        "state": {
+                            "none": "Ingen"
+                        }
+                    }
+                }
             }
         },
         "camera": {

--- a/custom_components/boschindego/translations/sv.json
+++ b/custom_components/boschindego/translations/sv.json
@@ -198,7 +198,7 @@
             },
             "calendar_slots": {
                 "state": {
-                    "SmartMowing active": "SmartMowing aktiv",
+                    "smartmowing active": "SmartMowing aktiv",
                     "off": "Av"
                 },
                 "name": "Planerade klipptider",
@@ -320,7 +320,7 @@
             "predictive_calendar_slots": {
                 "name": "SmartMowing-blockerade tider",
                 "state": {
-                    "Manual calendar active": "Manuell kalender aktiv",
+                    "manual calendar active": "Manuell kalender aktiv",
                     "off": "Av"
                 },
                 "state_attributes": {
@@ -362,7 +362,7 @@
             "predictive_schedule": {
                 "name": "SmartMowing-schema",
                 "state": {
-                    "Manual calendar active": "Manuell kalender aktiv",
+                    "manual calendar active": "Manuell kalender aktiv",
                     "none": "Ingen"
                 },
                 "state_attributes": {


### PR DESCRIPTION
Made some changes on die already existing sensors *calendar_slots and *predictive_calendar_slots.
Additionally some improvements on the SmartMowing switch.

1. The SmartMowing switch immediately updates the calendar in the Bosch App to SmartMowing and also the sensor.*mowing_mode now immediately changes it state when toggling the switch in HA. Right now it can take up to 10 minutes when the mowing mode is changed in the Bosch App because the switch and mowing mode is part of the regular 10 min update. We could shorten the refresh intervall but i dont know if this will cause too many API calls. 

2. sensor.indego_xxx_calendar_slots always shows the configured time slots in the attributes and if the manual calendar ist active it will also show the next configured slot in its state. If the manual calendar is inactive and SmartMowing is enabled its state will show "SmartMowing active".

3. sensor.indego_xxx_predictive_calendar_slots now shows the attributes earliest_start, latest_end, blocked_before and blocked_after. These are the timeslots which can be configured during the setup of a new SmartMowing schedule. The state of the sensor will show e.g. "00:00 - 08:00, 20:00 - 23:59" if you have configured that the mower should not mow before 08:00 and not after 20:00. If SmartMowing is disabled and the manual calendar is used the state will show "Manual Calendar active".

4. sensor.indego_xxx_predictive_schedule is a new sensor in the release. If SmartMowing is disabled and the manual calendar is used the state will show "Manual Calendar active". Otherwise it will show the next upcoming mowing timeslot. It hase a lot of attributes which show the next timeslot and day and also information for each day when the mower will mow and which times are excluded. here is an example:
```
schedule_monday: 08:00-11:00, 14:00-22:00
exclusion_monday_user: 00:00-05:00, 22:00-23:59
exclusion_monday_weather: 05:00-06:00, 11:00-14:00
```
  What you see is that the mower will mow from 08:00-11:00 and 14:00-22:00. It will not mow from 00:00-05:00 and 22:00-23:59 because this was set as non mowing times (like mentioned in the description above. Additionally it shows that the mower will not mow from 05:00-06:00 and 11:00-14:00 because of the weather data from Bosch.

5. In the service indego.set_calendar_slots it is now possible to choose mutliple days.

6. New service set_predictive_mowing_window to change the times in which the mower can mow (as described in point 3 - earliest_start, latest_end) 

7. All translation files updated for the new sensors and service. Unfortunately i was not able to translate the states of the attributes. The attributes are mentioned in the translation files but they are not working yet.

8. Updated version in manifest.json to 1.6.5