### PR TITLE
Fix predictive slot state and predictive schedule

### DIFF
--- a/custom_components/boschindego/__init__.py
+++ b/custom_components/boschindego/__init__.py
@@ -859,6 +859,23 @@ def _is_smartmowing_active(generic_data, forced_mowing_mode=None) -> bool:
     )
     return str(mowing_mode).lower() == "smartmowing"
 
+def _is_calendar_selection_required(generic_data) -> bool:
+    mowing_mode = getattr(
+        generic_data,
+        "mowing_mode_description",
+        None,
+    )
+    alm_mode = getattr(
+        generic_data,
+        "alm_mode",
+        None,
+    )
+
+    return (
+        str(mowing_mode).lower() == "manual"
+        or str(alm_mode).lower() == "manual"
+    )
+
 LOCALIZED_TEXTS = {
     "de": {
         "allowed_mowing_time": "Erlaubte Mähzeit",
@@ -1425,6 +1442,18 @@ class IndegoHub:
 
         await self._update_calendar()
 
+    async def async_select_manual_calendar(self):
+        """Try to select the manual calendar after SmartMowing was disabled."""
+        await self._indego_client.update_calendar()
+        calendar = getattr(self._indego_client, "calendar", None)
+
+        payload = _calendar_to_payload(calendar, selected_cal=2)
+
+        result = await self._indego_client.put(
+            f"alms/{self._serial}/calendar",
+            payload,
+        )
+
     async def async_set_predictive_mowing_window(
         self,
         earliest_start: str,
@@ -1967,6 +1996,7 @@ class IndegoHub:
 
         calendar = getattr(self._indego_client, "predictive_calendar", None)
 
+
         if ENTITY_PREDICTIVE_CALENDAR_SLOTS not in self.entities:
             return
 
@@ -2030,7 +2060,7 @@ class IndegoHub:
         elif today_slots:
             sensor.state = ", ".join(today_slots)
 
-        elif self._forced_mowing_mode == "Calendar":
+        elif _is_calendar_selection_required(self._indego_client.generic_data):
             sensor.state = "calendar_selection_required"
 
         else:
@@ -2416,15 +2446,18 @@ class IndegoHub:
                     self._indego_client.generic_data,
                     "mowing_mode_description",
                     STATE_UNKNOWN,
+                    
                 )
 
+                effective_mowing_mode = self._forced_mowing_mode or mowing_mode
+
                 if ENTITY_MOWING_MODE in self.entities:
-                    self.entities[ENTITY_MOWING_MODE].state = mowing_mode
+                    self.entities[ENTITY_MOWING_MODE].state = effective_mowing_mode
                     _LOGGER.debug("Mowing mode: %s", mowing_mode)
 
                 if ENTITY_SMARTMOWING_SWITCH in self.entities:
                     self.entities[ENTITY_SMARTMOWING_SWITCH].is_on = (
-                        str(mowing_mode).lower() == "smartmowing"
+                        str(effective_mowing_mode).lower() == "smartmowing"
                     )
 
             else:

--- a/custom_components/boschindego/__init__.py
+++ b/custom_components/boschindego/__init__.py
@@ -448,8 +448,10 @@ ENTITY_DEFINITIONS = {
             "last_updated",
             "smartmowing_enabled",
             "mowing_mode",
+            "allowed_mowing_time",
             "earliest_start",
             "latest_end",
+            "blocked_time",
             "blocked_before",
             "blocked_after",
         ],
@@ -697,12 +699,14 @@ def _predictive_calendar_payload(earliest_start: str, latest_end: str) -> dict:
         ],
     }
 
-def _predictive_calendar_window(calendar) -> dict:
+def _predictive_calendar_window(calendar, hass) -> dict:
     result = {
         "earliest_start": "not_enabled",
         "latest_end": "not_enabled",
         "blocked_before": "not_enabled",
         "blocked_after": "not_enabled",
+        "allowed_mowing_time": "not_enabled",
+        "blocked_time": "not_enabled",
     }
 
     if calendar is None or not getattr(calendar, "days", None):
@@ -718,6 +722,18 @@ def _predictive_calendar_window(calendar) -> dict:
     if len(slots) > 1 and getattr(slots[1], "En", False):
         result["blocked_after"] = _format_calendar_slot(slots[1])
         result["latest_end"] = f"{slots[1].StHr:02d}:{slots[1].StMin:02d}"
+
+    if (
+        result["earliest_start"] != "not_enabled"
+        and result["latest_end"] != "not_enabled"
+    ):
+        result["allowed_mowing_time"] = (
+            f"{_localized_text(hass, 'allowed_mowing_time')} "
+            f"{result['earliest_start']}-{result['latest_end']}"
+        )
+        result["blocked_time"] = (
+            f"{result['latest_end']}-{result['earliest_start']}"
+        )
 
     return result
 
@@ -760,7 +776,7 @@ def _schedule_slot_to_text(slot) -> str:
     )
 
 
-def _predictive_schedule_attributes(schedule) -> dict:
+def _predictive_schedule_attributes(schedule, hass) -> dict:
     day_names = [
         "monday",
         "tuesday",
@@ -804,7 +820,9 @@ def _predictive_schedule_attributes(schedule) -> dict:
             attrs[f"schedule_{day_name}"] = ", ".join(slot_texts)
 
             if attrs["next_mow_slot"] == "none":
-                attrs["next_mow_slot"] = f"{day_name} {slot_texts[0]}"
+                attrs["next_mow_slot"] = (
+                    f"{_localized_text(hass, day_name)} {slot_texts[0]}"
+                )
                 attrs["next_mow_day"] = day_name
                 attrs["next_mow_time"] = slot_texts[0]
 
@@ -833,13 +851,139 @@ def _predictive_schedule_attributes(schedule) -> dict:
 
     return attrs
 
-def _is_smartmowing_active(generic_data) -> bool:
-    mowing_mode = getattr(
+def _is_smartmowing_active(generic_data, forced_mowing_mode=None) -> bool:
+    mowing_mode = forced_mowing_mode or getattr(
         generic_data,
         "mowing_mode_description",
         None,
     )
     return str(mowing_mode).lower() == "smartmowing"
+
+LOCALIZED_TEXTS = {
+    "de": {
+        "allowed_mowing_time": "Erlaubte Mähzeit",
+        "monday": "Montag",
+        "tuesday": "Dienstag",
+        "wednesday": "Mittwoch",
+        "thursday": "Donnerstag",
+        "friday": "Freitag",
+        "saturday": "Samstag",
+        "sunday": "Sonntag",
+    },
+    "en": {
+        "allowed_mowing_time": "Allowed mowing time",
+        "monday": "Monday",
+        "tuesday": "Tuesday",
+        "wednesday": "Wednesday",
+        "thursday": "Thursday",
+        "friday": "Friday",
+        "saturday": "Saturday",
+        "sunday": "Sunday",
+    },
+    "da": {
+        "allowed_mowing_time": "Tilladt klippetid",
+        "monday": "Mandag",
+        "tuesday": "Tirsdag",
+        "wednesday": "Onsdag",
+        "thursday": "Torsdag",
+        "friday": "Fredag",
+        "saturday": "Lørdag",
+        "sunday": "Søndag",
+    },
+    "es": {
+        "allowed_mowing_time": "Tiempo de corte permitido",
+        "monday": "Lunes",
+        "tuesday": "Martes",
+        "wednesday": "Miércoles",
+        "thursday": "Jueves",
+        "friday": "Viernes",
+        "saturday": "Sábado",
+        "sunday": "Domingo",
+    },
+    "fr": {
+        "allowed_mowing_time": "Heure de tonte autorisée",
+        "monday": "Lundi",
+        "tuesday": "Mardi",
+        "wednesday": "Mercredi",
+        "thursday": "Jeudi",
+        "friday": "Vendredi",
+        "saturday": "Samedi",
+        "sunday": "Dimanche",
+    },
+    "it": {
+        "allowed_mowing_time": "Orario di taglio consentito",
+        "monday": "Lunedì",
+        "tuesday": "Martedì",
+        "wednesday": "Mercoledì",
+        "thursday": "Giovedì",
+        "friday": "Venerdì",
+        "saturday": "Sabato",
+        "sunday": "Domenica",
+    },
+    "nl": {
+        "allowed_mowing_time": "Toegestane maaitijd",
+        "monday": "Maandag",
+        "tuesday": "Dinsdag",
+        "wednesday": "Woensdag",
+        "thursday": "Donderdag",
+        "friday": "Vrijdag",
+        "saturday": "Zaterdag",
+        "sunday": "Zondag",
+    },
+    "no": {
+        "allowed_mowing_time": "Tillatt klippetid",
+        "monday": "Mandag",
+        "tuesday": "Tirsdag",
+        "wednesday": "Onsdag",
+        "thursday": "Torsdag",
+        "friday": "Fredag",
+        "saturday": "Lørdag",
+        "sunday": "Søndag",
+    },
+    "pl": {
+        "allowed_mowing_time": "Dozwolony czas koszenia",
+        "monday": "Poniedziałek",
+        "tuesday": "Wtorek",
+        "wednesday": "Środa",
+        "thursday": "Czwartek",
+        "friday": "Piątek",
+        "saturday": "Sobota",
+        "sunday": "Niedziela",
+    },
+    "sk": {
+        "allowed_mowing_time": "Povolený čas kosenia",
+        "monday": "Pondelok",
+        "tuesday": "Utorok",
+        "wednesday": "Streda",
+        "thursday": "Štvrtok",
+        "friday": "Piatok",
+        "saturday": "Sobota",
+        "sunday": "Nedeľa",
+    },
+    "sv": {
+        "allowed_mowing_time": "Tillåten klipptid",
+        "monday": "Måndag",
+        "tuesday": "Tisdag",
+        "wednesday": "Onsdag",
+        "thursday": "Torsdag",
+        "friday": "Fredag",
+        "saturday": "Lördag",
+        "sunday": "Söndag",
+    },
+}
+
+
+def _language_code(hass) -> str:
+    language = getattr(hass.config, "language", None) or "en"
+    return language.split("-")[0].lower()
+
+
+def _localized_text(hass, key: str) -> str:
+    language = _language_code(hass)
+    return LOCALIZED_TEXTS.get(
+        language,
+        LOCALIZED_TEXTS["en"],
+    ).get(key, key)
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Load a config entry."""
@@ -934,15 +1078,25 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         _LOGGER.info("Setting smart mowing mode to: %s (Mower: %s)", enable_bool, instance._serial)
 
+
         await instance._indego_client.put_mow_mode(enable_bool)
+
+        instance._forced_mowing_mode = "SmartMowing" if enable_bool else "Calendar"
 
         if ENTITY_SMARTMOWING_SWITCH in instance.entities:
             instance.entities[ENTITY_SMARTMOWING_SWITCH].is_on = enable_bool
 
+        if ENTITY_MOWING_MODE in instance.entities:
+            instance.entities[ENTITY_MOWING_MODE].state = (
+                "SmartMowing" if enable_bool else "Calendar"
+            )
+
         await asyncio.sleep(3)
 
-        await instance._update_generic_data()
         await instance._update_predictive_calendar()
+        await instance._update_predictive_schedule()
+        await instance._update_calendar()
+        await instance._update_generic_data()
 
     async def async_delete_alert(call):
         """Handle the service call."""
@@ -1209,6 +1363,7 @@ class IndegoHub:
         self._last_service_error = None  # Track last Bosch service error (5xx)
         self._consecutive_timeouts = 0  # Track consecutive position update timeouts
         self._last_timeout_warning_time = None  # Prevent timeout spam
+        self._forced_mowing_mode = None # force mowing mode and calendar sensors to update
 
         async def async_token_refresh() -> str:
             await session.async_ensure_token_valid()
@@ -1299,19 +1454,17 @@ class IndegoHub:
 
         schedule = getattr(self._indego_client, "predictive_schedule", None)
 
-#        _LOGGER.warning(
-#            "PREDICTIVE SCHEDULE = %r",
-#            schedule
-#        )
-
         if ENTITY_PREDICTIVE_SCHEDULE not in self.entities:
             return
 
-        attrs = _predictive_schedule_attributes(schedule)
+        attrs = _predictive_schedule_attributes(schedule, self._hass)
 
         sensor = self.entities[ENTITY_PREDICTIVE_SCHEDULE]
 
-        if not _is_smartmowing_active(self._indego_client.generic_data):
+        if not _is_smartmowing_active(
+            self._indego_client.generic_data,
+            self._forced_mowing_mode,
+        ):
             sensor.state = "manual_calendar_active"
         else:
             sensor.state = attrs["next_mow_slot"]
@@ -1823,19 +1976,22 @@ class IndegoHub:
             None,
         )
 
-        smartmowing_enabled = str(mowing_mode).lower() == "smartmowing"
+        smartmowing_enabled = _is_smartmowing_active(
+            self._indego_client.generic_data,
+            self._forced_mowing_mode,
+        )
 
-        window = _predictive_calendar_window(calendar)
+        window = _predictive_calendar_window(calendar, self._hass)
 
         sensor = self.entities[ENTITY_PREDICTIVE_CALENDAR_SLOTS]
 
-        if not _is_smartmowing_active(self._indego_client.generic_data):
-            sensor.state = "manual_calendar_active"
-        elif (
-            window["earliest_start"] != "not_enabled"
-            and window["latest_end"] != "not_enabled"
+        if not _is_smartmowing_active(
+            self._indego_client.generic_data,
+            self._forced_mowing_mode,
         ):
-            sensor.state = f"{window['earliest_start']}-{window['latest_end']}"
+            sensor.state = "manual_calendar_active"
+        elif window["allowed_mowing_time"] != "not_enabled":
+            sensor.state = window["allowed_mowing_time"]
         else:
             sensor.state = "off"
 
@@ -1843,7 +1999,7 @@ class IndegoHub:
             {
                 "last_updated": last_updated_now(),
                 "smartmowing_enabled": smartmowing_enabled,
-                "mowing_mode": mowing_mode,
+                "mowing_mode": self._forced_mowing_mode or mowing_mode,
                 **window,
             }
         )
@@ -1865,10 +2021,20 @@ class IndegoHub:
 
         sensor = self.entities[ENTITY_CALENDAR_SLOTS]
 
-        if _is_smartmowing_active(self._indego_client.generic_data):
+        if _is_smartmowing_active(
+            self._indego_client.generic_data,
+            self._forced_mowing_mode,
+        ):
             sensor.state = "smartmowing_active"
+
+        elif today_slots:
+            sensor.state = ", ".join(today_slots)
+
+        elif self._forced_mowing_mode == "Calendar":
+            sensor.state = "calendar_selection_required"
+
         else:
-            sensor.state = ", ".join(today_slots) if today_slots else "off"
+            sensor.state = "off"
 
         sensor.set_attributes(
             {

--- a/custom_components/boschindego/manifest.json
+++ b/custom_components/boschindego/manifest.json
@@ -19,5 +19,5 @@
   "requirements": [
     "pyIndego==3.2.2"
   ],
-  "version": "1.6.7"
+  "version": "1.6.8"
 }

--- a/custom_components/boschindego/switch.py
+++ b/custom_components/boschindego/switch.py
@@ -109,16 +109,32 @@ class IndegoSwitch(IndegoEntity, SwitchEntity):
     async def async_turn_on(self, **kwargs) -> None:
         """Turn the switch on."""
         _LOGGER.debug("Turning on SmartMowing for mower %s", self._indego_hub.serial)
-        await self._indego_hub._indego_client.put_mow_mode("true")
-        await self._indego_hub._update_generic_data()
+
+        self._indego_hub._forced_mowing_mode = "SmartMowing"
+
+        await self._indego_hub._indego_client.put_mow_mode(True)
+
         self.is_on = True
+
+        await self._indego_hub._update_predictive_calendar()
+        await self._indego_hub._update_predictive_schedule()
+        await self._indego_hub._update_calendar()
+        await self._indego_hub._update_generic_data()
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the switch off."""
         _LOGGER.debug("Turning off SmartMowing for mower %s", self._indego_hub.serial)
-        await self._indego_hub._indego_client.put_mow_mode("false")
-        await self._indego_hub._update_generic_data()
+
+        self._indego_hub._forced_mowing_mode = "Calendar"
+
+        await self._indego_hub._indego_client.put_mow_mode(False)
+
         self.is_on = False
+
+        await self._indego_hub._update_predictive_calendar()
+        await self._indego_hub._update_predictive_schedule()
+        await self._indego_hub._update_calendar()
+        await self._indego_hub._update_generic_data()
 
     @property
     def state(self) -> str:

--- a/custom_components/boschindego/switch.py
+++ b/custom_components/boschindego/switch.py
@@ -15,6 +15,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from .mixins import IndegoEntity
 from .const import DATA_UPDATED, DOMAIN
 
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -129,12 +130,23 @@ class IndegoSwitch(IndegoEntity, SwitchEntity):
 
         await self._indego_hub._indego_client.put_mow_mode(False)
 
+        await self._indego_hub.async_select_manual_calendar()
+
         self.is_on = False
 
         await self._indego_hub._update_predictive_calendar()
         await self._indego_hub._update_predictive_schedule()
         await self._indego_hub._update_calendar()
         await self._indego_hub._update_generic_data()
+
+        mowing_mode = getattr(
+            self._indego_hub._indego_client.generic_data,
+            "mowing_mode_description",
+            None,
+        )
+
+        if str(mowing_mode).lower() == "calendar":
+            self._indego_hub._forced_mowing_mode = None
 
     @property
     def state(self) -> str:

--- a/custom_components/boschindego/translations/da.json
+++ b/custom_components/boschindego/translations/da.json
@@ -199,6 +199,7 @@
             "calendar_slots": {
                 "state": {
                     "smartmowing_active": "SmartMowing aktiv",
+                    "calendar_selection_required": "Valg af kalender påkrævet",
                     "off": "Fra"
                 },
                 "name": "Planlagte klippetider",

--- a/custom_components/boschindego/translations/de.json
+++ b/custom_components/boschindego/translations/de.json
@@ -405,6 +405,7 @@
                 "name": "Geplante Mähzeiten",
                 "state": {
                     "smartmowing_active": "SmartMowing aktiv",
+                    "calendar_selection_required": "Kalenderauswahl erforderlich",
                     "off": "Aus"
                 },
                 "state_attributes": {

--- a/custom_components/boschindego/translations/en.json
+++ b/custom_components/boschindego/translations/en.json
@@ -199,6 +199,7 @@
             "calendar_slots": {
                 "state": {
                     "smartmowing_active": "SmartMowing active",
+                    "calendar_selection_required": "Kalenderauswahl erforderlich",
                     "off": "Off"
                 },
                 "name": "Planned mowing times",

--- a/custom_components/boschindego/translations/es.json
+++ b/custom_components/boschindego/translations/es.json
@@ -199,6 +199,7 @@
             "calendar_slots": {
                 "state": {
                     "smartmowing_active": "SmartMowing activo",
+                    "calendar_selection_required": "Selección de calendario requerida",
                     "off": "Apagado"
                 },
                 "name": "Tiempos de corte planificados",

--- a/custom_components/boschindego/translations/fr.json
+++ b/custom_components/boschindego/translations/fr.json
@@ -199,6 +199,7 @@
             "calendar_slots": {
                 "state": {
                     "smartmowing_active": "SmartMowing actif",
+                    "calendar_selection_required": "Sélection du calendrier requise",
                     "off": "Désactivé"
                 },
                 "name": "Horaires de tonte planifiés",

--- a/custom_components/boschindego/translations/it.json
+++ b/custom_components/boschindego/translations/it.json
@@ -199,6 +199,7 @@
             "calendar_slots": {
                 "state": {
                     "smartmowing_active": "SmartMowing attivo",
+                    "calendar_selection_required": "Selezione del calendario richiesta",
                     "off": "Spento"
                 },
                 "name": "Orari di taglio pianificati",

--- a/custom_components/boschindego/translations/nl.json
+++ b/custom_components/boschindego/translations/nl.json
@@ -199,6 +199,7 @@
             "calendar_slots": {
                 "state": {
                     "smartmowing_active": "SmartMowing actief",
+                    "calendar_selection_required": "Kalenderselectie vereist",
                     "off": "Uit"
                 },
                 "name": "Geplande maaitijden",

--- a/custom_components/boschindego/translations/no.json
+++ b/custom_components/boschindego/translations/no.json
@@ -199,6 +199,7 @@
             "calendar_slots": {
                 "state": {
                     "smartmowing_active": "SmartMowing aktiv",
+                    "calendar_selection_required": "Kalendervalg kreves",
                     "off": "Av"
                 },
                 "name": "Planlagte klippetider",

--- a/custom_components/boschindego/translations/pl.json
+++ b/custom_components/boschindego/translations/pl.json
@@ -199,6 +199,7 @@
             "calendar_slots": {
                 "state": {
                     "smartmowing_active": "SmartMowing aktywny",
+                    "calendar_selection_required": "Wymagany wybór kalendarza",
                     "off": "Wyłączone"
                 },
                 "name": "Zaplanowane czasy koszenia",

--- a/custom_components/boschindego/translations/sk.json
+++ b/custom_components/boschindego/translations/sk.json
@@ -199,6 +199,7 @@
             "calendar_slots": {
                 "state": {
                     "smartmowing_active": "SmartMowing aktívny",
+                    "calendar_selection_required": "Vyžaduje sa výber kalendára",
                     "off": "Vypnuté"
                 },
                 "name": "Naplánované časy kosenia",

--- a/custom_components/boschindego/translations/sv.json
+++ b/custom_components/boschindego/translations/sv.json
@@ -199,6 +199,7 @@
             "calendar_slots": {
                 "state": {
                     "smartmowing_active": "SmartMowing aktiv",
+                    "calendar_selection_required": "Kalenderval krävs",
                     "off": "Av"
                 },
                 "name": "Planerade klipptider",


### PR DESCRIPTION
## Description
1. Added translations for the state of sensor.indego_xxx_predictive_schedule in __init__.py
2. Fixed state of sensor.indego_xxx_predictive_calendar_slots, it will now show "Allowed mow times 08:00 - 20:00" instead of only the time.
3. Improved SmartMowing switch handling. toggling the switch will now directly change the state of sensor.indego_xxx_calendar_slots, sensor.indego_xxx_predictive_schedule and sensor.indego_xxx_predictive_calendar_slots depending on the state of the switch.
4. Added translation for all mentioned changes.

~~Additional Information:
The sensor sensor.indego_xxx_predictive_calendar_slots will show "calendar_selection_required" after turning the SmartMowing switch off. This means that the manual calendar has to be re-activated in the Bosch App of the mower. At the moment there is no option in pyIndego to send this command to the API.~~


## Related Issues
<!-- Link the issues that will be closed by this PR (e.g., Closes #123) -->
Closes #46 and #47 

## Type of Change
- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🧹 Refactoring (code optimization, no logic changes)
- [ ] 📝 Documentation (updates to README, code comments, etc.)

## Checklist
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have tested my changes locally.
- [X] The manifest version has been updated (if applicable).
